### PR TITLE
Implements core#109155 for custom integration

### DIFF
--- a/custom_components/tuya/__init__.py
+++ b/custom_components/tuya/__init__.py
@@ -1,119 +1,75 @@
 """Support for Tuya Smart devices."""
 from __future__ import annotations
 
-from typing import NamedTuple
+import logging
+from typing import Any, NamedTuple
 
-import requests
-from tuya_iot import (
-    AuthType,
-    TuyaDevice,
-    TuyaDeviceListener,
-    TuyaDeviceManager,
-    TuyaHomeManager,
-    TuyaOpenAPI,
-    TuyaOpenMQ,
+from tuya_sharing import (
+    CustomerDevice,
+    Manager,
+    SharingDeviceListener,
+    SharingTokenListener,
 )
 
-from homeassistant.components.light import DOMAIN as LIGHT_DOMAIN
-from homeassistant.components.switch import DOMAIN as SWITCH_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import ConfigEntryNotReady
-from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import dispatcher_send
 
 from .const import (
-    CONF_ACCESS_ID,
-    CONF_ACCESS_SECRET,
     CONF_APP_TYPE,
-    CONF_AUTH_TYPE,
-    CONF_COUNTRY_CODE,
     CONF_ENDPOINT,
-    CONF_PASSWORD,
-    CONF_PROJECT_TYPE,
-    CONF_USERNAME,
+    CONF_TERMINAL_ID,
+    CONF_TOKEN_INFO,
+    CONF_USER_CODE,
     DOMAIN,
     LOGGER,
     PLATFORMS,
+    TUYA_CLIENT_ID,
     TUYA_DISCOVERY_NEW,
     TUYA_HA_SIGNAL_UPDATE_ENTITY,
-    DPCode,
 )
+
+# Suppress logs from the library, it logs unneeded on error
+logging.getLogger("tuya_sharing").setLevel(logging.CRITICAL)
 
 
 class HomeAssistantTuyaData(NamedTuple):
     """Tuya data stored in the Home Assistant data object."""
 
-    device_listener: TuyaDeviceListener
-    device_manager: TuyaDeviceManager
-    home_manager: TuyaHomeManager
+    manager: Manager
+    listener: SharingDeviceListener
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Async setup hass config entry."""
-    hass.data.setdefault(DOMAIN, {})
+    if CONF_APP_TYPE in entry.data:
+        raise ConfigEntryAuthFailed("Authentication failed. Please re-authenticate.")
 
-    # Project type has been renamed to auth type in the upstream Tuya IoT SDK.
-    # This migrates existing config entries to reflect that name change.
-    if CONF_PROJECT_TYPE in entry.data:
-        data = {**entry.data, CONF_AUTH_TYPE: entry.data[CONF_PROJECT_TYPE]}
-        data.pop(CONF_PROJECT_TYPE)
-        hass.config_entries.async_update_entry(entry, data=data)
-
-    auth_type = AuthType(entry.data[CONF_AUTH_TYPE])
-    api = TuyaOpenAPI(
-        endpoint=entry.data[CONF_ENDPOINT],
-        access_id=entry.data[CONF_ACCESS_ID],
-        access_secret=entry.data[CONF_ACCESS_SECRET],
-        auth_type=auth_type,
+    token_listener = TokenListener(hass, entry)
+    manager = Manager(
+        TUYA_CLIENT_ID,
+        entry.data[CONF_USER_CODE],
+        entry.data[CONF_TERMINAL_ID],
+        entry.data[CONF_ENDPOINT],
+        entry.data[CONF_TOKEN_INFO],
+        token_listener,
     )
 
-    api.set_dev_channel("hass")
-
-    try:
-        if auth_type == AuthType.CUSTOM:
-            response = await hass.async_add_executor_job(
-                api.connect, entry.data[CONF_USERNAME], entry.data[CONF_PASSWORD]
-            )
-        else:
-            response = await hass.async_add_executor_job(
-                api.connect,
-                entry.data[CONF_USERNAME],
-                entry.data[CONF_PASSWORD],
-                entry.data[CONF_COUNTRY_CODE],
-                entry.data[CONF_APP_TYPE],
-            )
-    except requests.exceptions.RequestException as err:
-        raise ConfigEntryNotReady(err) from err
-
-    if response.get("success", False) is False:
-        raise ConfigEntryNotReady(response)
-
-    tuya_mq = TuyaOpenMQ(api)
-    tuya_mq.start()
-
-    device_ids: set[str] = set()
-    device_manager = TuyaDeviceManager(api, tuya_mq)
-    home_manager = TuyaHomeManager(api, tuya_mq, device_manager)
-    listener = DeviceListener(hass, device_manager, device_ids)
-    device_manager.add_device_listener(listener)
-
-    hass.data[DOMAIN][entry.entry_id] = HomeAssistantTuyaData(
-        device_listener=listener,
-        device_manager=device_manager,
-        home_manager=home_manager,
+    listener = DeviceListener(hass, manager)
+    manager.add_device_listener(listener)
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = HomeAssistantTuyaData(
+        manager=manager, listener=listener
     )
 
     # Get devices & clean up device entities
-    await hass.async_add_executor_job(home_manager.update_device_cache)
-    await cleanup_device_registry(hass, device_manager)
-
-    # Migrate old unique_ids to the new format
-    async_migrate_entities_unique_ids(hass, entry, device_manager)
+    await hass.async_add_executor_job(manager.update_device_cache)
+    await cleanup_device_registry(hass, manager)
 
     # Register known device IDs
     device_registry = dr.async_get(hass)
-    for device in device_manager.device_map.values():
+    for device in manager.device_map.values():
         device_registry.async_get_or_create(
             config_entry_id=entry.entry_id,
             identifiers={(DOMAIN, device.id)},
@@ -121,15 +77,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             name=device.name,
             model=f"{device.product_name} (unsupported)",
         )
-        device_ids.add(device.id)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+    # If the device does not register any entities, the device does not need to subscribe
+    # So the subscription is here
+    await hass.async_add_executor_job(manager.refresh_mq)
     return True
 
 
-async def cleanup_device_registry(
-    hass: HomeAssistant, device_manager: TuyaDeviceManager
-) -> None:
+async def cleanup_device_registry(hass: HomeAssistant, device_manager: Manager) -> None:
     """Remove deleted device registry entry if there are no remaining entities."""
     device_registry = dr.async_get(hass)
     for dev_id, device_entry in list(device_registry.devices.items()):
@@ -139,141 +95,45 @@ async def cleanup_device_registry(
                 break
 
 
-@callback
-def async_migrate_entities_unique_ids(
-    hass: HomeAssistant, config_entry: ConfigEntry, device_manager: TuyaDeviceManager
-) -> None:
-    """Migrate unique_ids in the entity registry to the new format."""
-    entity_registry = er.async_get(hass)
-    registry_entries = er.async_entries_for_config_entry(
-        entity_registry, config_entry.entry_id
-    )
-    light_entries = {
-        entry.unique_id: entry
-        for entry in registry_entries
-        if entry.domain == LIGHT_DOMAIN
-    }
-    switch_entries = {
-        entry.unique_id: entry
-        for entry in registry_entries
-        if entry.domain == SWITCH_DOMAIN
-    }
-
-    for device in device_manager.device_map.values():
-        # Old lights where in `tuya.{device_id}` format, now the DPCode is added.
-        #
-        # If the device is a previously supported light category and still has
-        # the old format for the unique ID, migrate it to the new format.
-        #
-        # Previously only devices providing the SWITCH_LED DPCode were supported,
-        # thus this can be added to those existing IDs.
-        #
-        # `tuya.{device_id}` -> `tuya.{device_id}{SWITCH_LED}`
-        if (
-            device.category in ("dc", "dd", "dj", "fs", "fwl", "jsq", "xdd", "xxj")
-            and (entry := light_entries.get(f"tuya.{device.id}"))
-            and f"tuya.{device.id}{DPCode.SWITCH_LED}" not in light_entries
-        ):
-            entity_registry.async_update_entity(
-                entry.entity_id, new_unique_id=f"tuya.{device.id}{DPCode.SWITCH_LED}"
-            )
-
-        # Old switches has different formats for the unique ID, but is mappable.
-        #
-        # If the device is a previously supported switch category and still has
-        # the old format for the unique ID, migrate it to the new format.
-        #
-        # `tuya.{device_id}` -> `tuya.{device_id}{SWITCH}`
-        # `tuya.{device_id}_1` -> `tuya.{device_id}{SWITCH_1}`
-        # ...
-        # `tuya.{device_id}_6` -> `tuya.{device_id}{SWITCH_6}`
-        # `tuya.{device_id}_usb1` -> `tuya.{device_id}{SWITCH_USB1}`
-        # ...
-        # `tuya.{device_id}_usb6` -> `tuya.{device_id}{SWITCH_USB6}`
-        #
-        # In all other cases, the unique ID is not changed.
-        if device.category in ("bh", "cwysj", "cz", "dlq", "kg", "kj", "pc", "xxj"):
-            for postfix, dpcode in (
-                ("", DPCode.SWITCH),
-                ("_1", DPCode.SWITCH_1),
-                ("_2", DPCode.SWITCH_2),
-                ("_3", DPCode.SWITCH_3),
-                ("_4", DPCode.SWITCH_4),
-                ("_5", DPCode.SWITCH_5),
-                ("_6", DPCode.SWITCH_6),
-                ("_usb1", DPCode.SWITCH_USB1),
-                ("_usb2", DPCode.SWITCH_USB2),
-                ("_usb3", DPCode.SWITCH_USB3),
-                ("_usb4", DPCode.SWITCH_USB4),
-                ("_usb5", DPCode.SWITCH_USB5),
-                ("_usb6", DPCode.SWITCH_USB6),
-            ):
-                if (
-                    entry := switch_entries.get(f"tuya.{device.id}{postfix}")
-                ) and f"tuya.{device.id}{dpcode}" not in switch_entries:
-                    entity_registry.async_update_entity(
-                        entry.entity_id, new_unique_id=f"tuya.{device.id}{dpcode}"
-                    )
-
-
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unloading the Tuya platforms."""
-    unload = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
-    if unload:
-        hass_data: HomeAssistantTuyaData = hass.data[DOMAIN][entry.entry_id]
-        hass_data.device_manager.mq.stop()
-        hass_data.device_manager.remove_device_listener(hass_data.device_listener)
-
-        hass.data[DOMAIN].pop(entry.entry_id)
-        if not hass.data[DOMAIN]:
-            hass.data.pop(DOMAIN)
-
-    return unload
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        tuya: HomeAssistantTuyaData = hass.data[DOMAIN][entry.entry_id]
+        if tuya.manager.mq is not None:
+            tuya.manager.mq.stop()
+        tuya.manager.remove_device_listener(tuya.listener)
+        await hass.async_add_executor_job(tuya.manager.unload)
+        del hass.data[DOMAIN][entry.entry_id]
+    return unload_ok
 
 
-class DeviceListener(TuyaDeviceListener):
+class DeviceListener(SharingDeviceListener):
     """Device Update Listener."""
-
-    # pylint: disable=arguments-differ
-    # Library incorrectly defines methods as 'classmethod'
-    # https://github.com/tuya/tuya-iot-python-sdk/pull/48
 
     def __init__(
         self,
         hass: HomeAssistant,
-        device_manager: TuyaDeviceManager,
-        device_ids: set[str],
+        manager: Manager,
     ) -> None:
         """Init DeviceListener."""
         self.hass = hass
-        self.device_manager = device_manager
-        self.device_ids = device_ids
+        self.manager = manager
 
-    def update_device(self, device: TuyaDevice) -> None:
+    def update_device(self, device: CustomerDevice) -> None:
         """Update device status."""
-        if device.id in self.device_ids:
-            LOGGER.debug(
-                "Received update for device %s: %s",
-                device.id,
-                self.device_manager.device_map[device.id].status,
-            )
-            dispatcher_send(self.hass, f"{TUYA_HA_SIGNAL_UPDATE_ENTITY}_{device.id}")
+        LOGGER.debug(
+            "Received update for device %s: %s",
+            device.id,
+            self.manager.device_map[device.id].status,
+        )
+        dispatcher_send(self.hass, f"{TUYA_HA_SIGNAL_UPDATE_ENTITY}_{device.id}")
 
-    def add_device(self, device: TuyaDevice) -> None:
+    def add_device(self, device: CustomerDevice) -> None:
         """Add device added listener."""
         # Ensure the device isn't present stale
         self.hass.add_job(self.async_remove_device, device.id)
 
-        self.device_ids.add(device.id)
         dispatcher_send(self.hass, TUYA_DISCOVERY_NEW, [device.id])
-
-        device_manager = self.device_manager
-        device_manager.mq.stop()
-        tuya_mq = TuyaOpenMQ(device_manager.api)
-        tuya_mq.start()
-
-        device_manager.mq = tuya_mq
-        tuya_mq.add_message_listener(device_manager.on_message)
 
     def remove_device(self, device_id: str) -> None:
         """Add device removed listener."""
@@ -289,4 +149,36 @@ class DeviceListener(TuyaDeviceListener):
         )
         if device_entry is not None:
             device_registry.async_remove_device(device_entry.id)
-            self.device_ids.discard(device_id)
+
+
+class TokenListener(SharingTokenListener):
+    """Token listener for upstream token updates."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+    ) -> None:
+        """Init TokenListener."""
+        self.hass = hass
+        self.entry = entry
+
+    def update_token(self, token_info: dict[str, Any]) -> None:
+        """Update token info in config entry."""
+        data = {
+            **self.entry.data,
+            CONF_TOKEN_INFO: {
+                "t": token_info["t"],
+                "uid": token_info["uid"],
+                "expire_time": token_info["expire_time"],
+                "access_token": token_info["access_token"],
+                "refresh_token": token_info["refresh_token"],
+            },
+        }
+
+        @callback
+        def async_update_entry() -> None:
+            """Update config entry."""
+            self.hass.config_entries.async_update_entry(self.entry, data=data)
+
+        self.hass.add_job(async_update_entry)

--- a/custom_components/tuya/alarm_control_panel.py
+++ b/custom_components/tuya/alarm_control_panel.py
@@ -1,9 +1,10 @@
 """Support for Tuya Alarm."""
 from __future__ import annotations
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from enum import StrEnum
 
-from homeassistant.backports.enum import StrEnum
+from tuya_sharing import CustomerDevice, Manager
+
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityDescription,
@@ -67,18 +68,16 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya siren."""
         entities: list[TuyaAlarmEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := ALARM.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaAlarmEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaAlarmEntity(device, hass_data.manager, description)
                         )
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -89,11 +88,12 @@ class TuyaAlarmEntity(TuyaEntity, AlarmControlPanelEntity):
     """Tuya Alarm Entity."""
 
     _attr_icon = "mdi:security"
+    _attr_name = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: AlarmControlPanelEntityDescription,
     ) -> None:
         """Init Tuya Alarm."""

--- a/custom_components/tuya/base.py
+++ b/custom_components/tuya/base.py
@@ -5,13 +5,13 @@ import base64
 from dataclasses import dataclass
 import json
 import struct
-from typing import Any, Literal, overload
+from typing import Any, Literal, Self, overload
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
-from typing_extensions import Self
+from tuya_sharing import CustomerDevice, Manager
 
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.helpers.entity import DeviceInfo, Entity
+from homeassistant.helpers.entity import Entity
 
 from .const import DOMAIN, LOGGER, TUYA_HA_SIGNAL_UPDATE_ENTITY, DPCode, DPType
 from .util import remap_value
@@ -135,9 +135,11 @@ class TuyaEntity(Entity):
     _attr_has_entity_name = True
     _attr_should_poll = False
 
-    def __init__(self, device: TuyaDevice, device_manager: TuyaDeviceManager) -> None:
+    def __init__(self, device: CustomerDevice, device_manager: Manager) -> None:
         """Init TuyaHaEntity."""
         self._attr_unique_id = f"tuya.{device.id}"
+        # TuyaEntity initialize mq can subscribe
+        device.set_up = True
         self.device = device
         self.device_manager = device_manager
 

--- a/custom_components/tuya/binary_sensor.py
+++ b/custom_components/tuya/binary_sensor.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
@@ -21,7 +21,7 @@ from .base import TuyaEntity
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode
 
 
-@dataclass
+@dataclass(frozen=True)
 class TuyaBinarySensorEntityDescription(BinarySensorEntityDescription):
     """Describes a Tuya binary sensor."""
 
@@ -51,68 +51,64 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
     "dgnbj": (
         TuyaBinarySensorEntityDescription(
             key=DPCode.GAS_SENSOR_STATE,
-            name="Gas",
             icon="mdi:gas-cylinder",
-            device_class=BinarySensorDeviceClass.SAFETY,
+            device_class=BinarySensorDeviceClass.GAS,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.CH4_SENSOR_STATE,
-            name="Methane",
+            translation_key="methane",
             device_class=BinarySensorDeviceClass.GAS,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.VOC_STATE,
-            name="Volatile organic compound",
+            translation_key="voc",
             device_class=BinarySensorDeviceClass.SAFETY,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.PM25_STATE,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=BinarySensorDeviceClass.SAFETY,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.CO_STATE,
-            name="Carbon monoxide",
+            translation_key="carbon_monoxide",
             icon="mdi:molecule-co",
             device_class=BinarySensorDeviceClass.SAFETY,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.CO2_STATE,
+            translation_key="carbon_dioxide",
             icon="mdi:molecule-co2",
-            name="Carbon dioxide",
             device_class=BinarySensorDeviceClass.SAFETY,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.CH2O_STATE,
-            name="Formaldehyde",
+            translation_key="formaldehyde",
             device_class=BinarySensorDeviceClass.SAFETY,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.DOORCONTACT_STATE,
-            name="Door",
             device_class=BinarySensorDeviceClass.DOOR,
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.WATERSENSOR_STATE,
-            name="Water leak",
             device_class=BinarySensorDeviceClass.MOISTURE,
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.PRESSURE_STATE,
-            name="Pressure",
+            translation_key="pressure",
             on_value="alarm",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.SMOKE_SENSOR_STATE,
-            name="Smoke",
             icon="mdi:smoke-detector",
             device_class=BinarySensorDeviceClass.SMOKE,
             on_value="alarm",
@@ -149,7 +145,7 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
     "cwwsq": (
         TuyaBinarySensorEntityDescription(
             key=DPCode.FEED_STATE,
-            name="Feeding",
+            translation_key="feeding",
             icon="mdi:information",
             on_value="feeding",
         ),
@@ -215,48 +211,44 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
     "ms": (
         TuyaBinarySensorEntityDescription(
             key=DPCode.OPEN_INSIDE,
-            name="Unlock inside of door",
             icon="mdi:home-export-outline",
+            translation_key="lock_open_inside",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.OPEN_CLOSE,
-            name="Locking and unlocking event",
             icon="mdi:lock-pattern",
+            translation_key="lock_open_close",
         ),
         TuyaBinarySensorEntityDescription(
-            key=DPCode.DOOR_OPENED,
-            name="Door",
-            device_class=BinarySensorDeviceClass.DOOR,
+            key=DPCode.DOOR_OPENED, device_class=BinarySensorDeviceClass.DOOR
         ),
         TuyaBinarySensorEntityDescription(
-            key=DPCode.REVERSE_LOCK,
-            name="Double locking status",
+            key=DPCode.REVERSE_LOCK, translation_key="lock_reverse"
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
+            translation_key="child_lock",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.DOORBELL,
-            name="Doorbell",
             device_class=BinarySensorDeviceClass.SOUND,
+            translation_key="lock_doorbell",
         ),
         TuyaBinarySensorEntityDescription(
-            key=DPCode.ANTI_LOCK_OUTSIDE,
-            name="Double locking by lifting up",
+            key=DPCode.ANTI_LOCK_OUTSIDE, translation_key="lock_anti_outside"
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.LOCK_MOTOR_STATE,
-            name="Status",
             device_class=BinarySensorDeviceClass.LOCK,
+            translation_key="lock_status",
         ),
         TuyaBinarySensorEntityDescription(
             key=DPCode.HIJACK,
-            name="Duress alert",
             icon="mdi:lock-alert-outline",
             device_class=BinarySensorDeviceClass.SAFETY,
+            translation_key="lock_duress_alert",
         ),
     ),
     # Luminance Sensor
@@ -264,7 +256,6 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
     "ldcg": (
         TuyaBinarySensorEntityDescription(
             key=DPCode.TEMPER_ALARM,
-            name="Tamper",
             device_class=BinarySensorDeviceClass.TAMPER,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
@@ -339,7 +330,6 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
     "wkf": (
         TuyaBinarySensorEntityDescription(
             key=DPCode.WINDOW_STATE,
-            name="Window",
             device_class=BinarySensorDeviceClass.WINDOW,
             on_value="opened",
         ),
@@ -367,7 +357,7 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
         TuyaBinarySensorEntityDescription(
             key=DPCode.SMOKE_SENSOR_STATE,
             device_class=BinarySensorDeviceClass.SMOKE,
-            on_value="1",
+            on_value={"1", "alarm"},
         ),
         TAMPER_BINARY_SENSOR,
     ),
@@ -377,21 +367,20 @@ BINARY_SENSORS: dict[str, tuple[TuyaBinarySensorEntityDescription, ...]] = {
         TuyaBinarySensorEntityDescription(
             key=f"{DPCode.SHOCK_STATE}_vibration",
             dpcode=DPCode.SHOCK_STATE,
-            name="Vibration",
             device_class=BinarySensorDeviceClass.VIBRATION,
             on_value="vibration",
         ),
         TuyaBinarySensorEntityDescription(
             key=f"{DPCode.SHOCK_STATE}_drop",
             dpcode=DPCode.SHOCK_STATE,
-            name="Drop",
+            translation_key="drop",
             icon="mdi:icon=package-down",
             on_value="drop",
         ),
         TuyaBinarySensorEntityDescription(
             key=f"{DPCode.SHOCK_STATE}_tilt",
             dpcode=DPCode.SHOCK_STATE,
-            name="Tilt",
+            translation_key="tilt",
             icon="mdi:spirit-level",
             on_value="tilt",
         ),
@@ -422,20 +411,20 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya binary sensor."""
         entities: list[TuyaBinarySensorEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := BINARY_SENSORS.get(device.category):
                 for description in descriptions:
                     dpcode = description.dpcode or description.key
                     if dpcode in device.status:
                         entities.append(
                             TuyaBinarySensorEntity(
-                                device, hass_data.device_manager, description
+                                device, hass_data.manager, description
                             )
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -449,8 +438,8 @@ class TuyaBinarySensorEntity(TuyaEntity, BinarySensorEntity):
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: TuyaBinarySensorEntityDescription,
     ) -> None:
         """Init Tuya binary sensor."""

--- a/custom_components/tuya/button.py
+++ b/custom_components/tuya/button.py
@@ -1,7 +1,7 @@
 """Support for Tuya buttons."""
 from __future__ import annotations
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.button import ButtonEntity, ButtonEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -22,31 +22,31 @@ BUTTONS: dict[str, tuple[ButtonEntityDescription, ...]] = {
     "sd": (
         ButtonEntityDescription(
             key=DPCode.RESET_DUSTER_CLOTH,
-            name="Reset duster cloth",
+            translation_key="reset_duster_cloth",
             icon="mdi:restart",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_EDGE_BRUSH,
-            name="Reset edge brush",
+            translation_key="reset_edge_brush",
             icon="mdi:restart",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_FILTER,
-            name="Reset filter",
+            translation_key="reset_filter",
             icon="mdi:air-filter",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_MAP,
-            name="Reset map",
+            translation_key="reset_map",
             icon="mdi:map-marker-remove",
             entity_category=EntityCategory.CONFIG,
         ),
         ButtonEntityDescription(
             key=DPCode.RESET_ROLL_BRUSH,
-            name="Reset roll brush",
+            translation_key="reset_roll_brush",
             icon="mdi:restart",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -56,7 +56,7 @@ BUTTONS: dict[str, tuple[ButtonEntityDescription, ...]] = {
     "hxd": (
         ButtonEntityDescription(
             key=DPCode.SWITCH_USB6,
-            name="Snooze",
+            translation_key="snooze",
             icon="mdi:sleep",
         ),
     ),
@@ -74,19 +74,17 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya buttons."""
         entities: list[TuyaButtonEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := BUTTONS.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaButtonEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaButtonEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -98,8 +96,8 @@ class TuyaButtonEntity(TuyaEntity, ButtonEntity):
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: ButtonEntityDescription,
     ) -> None:
         """Init Tuya button."""

--- a/custom_components/tuya/camera.py
+++ b/custom_components/tuya/camera.py
@@ -1,7 +1,7 @@
 """Support for Tuya cameras."""
 from __future__ import annotations
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components import ffmpeg
 from homeassistant.components.camera import Camera as CameraEntity, CameraEntityFeature
@@ -34,13 +34,13 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya camera."""
         entities: list[TuyaCameraEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if device.category in CAMERAS:
-                entities.append(TuyaCameraEntity(device, hass_data.device_manager))
+                entities.append(TuyaCameraEntity(device, hass_data.manager))
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -52,11 +52,12 @@ class TuyaCameraEntity(TuyaEntity, CameraEntity):
 
     _attr_supported_features = CameraEntityFeature.STREAM
     _attr_brand = "Tuya"
+    _attr_name = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
     ) -> None:
         """Init Tuya Camera."""
         super().__init__(device, device_manager)

--- a/custom_components/tuya/climate.py
+++ b/custom_components/tuya/climate.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.climate import (
     SWING_BOTH,
@@ -39,14 +39,14 @@ TUYA_HVAC_TO_HA = {
 }
 
 
-@dataclass
+@dataclass(frozen=True)
 class TuyaClimateSensorDescriptionMixin:
     """Define an entity description mixin for climate entities."""
 
     switch_only_hvac_mode: HVACMode
 
 
-@dataclass
+@dataclass(frozen=True)
 class TuyaClimateEntityDescription(
     ClimateEntityDescription, TuyaClimateSensorDescriptionMixin
 ):
@@ -98,18 +98,19 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya climate."""
         entities: list[TuyaClimateEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if device and device.category in CLIMATE_DESCRIPTIONS:
                 entities.append(
                     TuyaClimateEntity(
                         device,
-                        hass_data.device_manager,
+                        hass_data.manager,
                         CLIMATE_DESCRIPTIONS[device.category],
+                        hass.config.units.temperature_unit,
                     )
                 )
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -125,12 +126,14 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
     _set_humidity: IntegerTypeData | None = None
     _set_temperature: IntegerTypeData | None = None
     entity_description: TuyaClimateEntityDescription
+    _attr_name = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: TuyaClimateEntityDescription,
+        system_temperature_unit: UnitOfTemperature,
     ) -> None:
         """Determine which values to use."""
         self._attr_target_temperature_step = 1.0
@@ -155,8 +158,8 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             ):
                 prefered_temperature_unit = UnitOfTemperature.FAHRENHEIT
 
-        # Default to Celsius
-        self._attr_temperature_unit = UnitOfTemperature.CELSIUS
+        # Default to System Temperature Unit
+        self._attr_temperature_unit = system_temperature_unit
 
         # Figure out current temperature, use preferred unit or what is available
         celsius_type = self.find_dpcode(
@@ -205,7 +208,7 @@ class TuyaClimateEntity(TuyaEntity, ClimateEntity):
             self._attr_target_temperature_step = self._set_temperature.step_scaled
 
         # Determine HVAC modes
-        self._attr_hvac_modes: list[str] = []
+        self._attr_hvac_modes: list[HVACMode] = []
         self._hvac_to_tuya = {}
         if enum_type := self.find_dpcode(
             DPCode.MODE, dptype=DPType.ENUM, prefer_function=True

--- a/custom_components/tuya/config_flow.py
+++ b/custom_components/tuya/config_flow.py
@@ -1,117 +1,65 @@
 """Config flow for Tuya."""
 from __future__ import annotations
 
+from collections.abc import Mapping
+from io import BytesIO
 from typing import Any
 
-from tuya_iot import AuthType, TuyaOpenAPI
+import segno
+from tuya_sharing import LoginControl
 import voluptuous as vol
 
-from homeassistant import config_entries
+from homeassistant.config_entries import ConfigEntry, ConfigFlow
+from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
-    CONF_ACCESS_ID,
-    CONF_ACCESS_SECRET,
-    CONF_APP_TYPE,
-    CONF_AUTH_TYPE,
-    CONF_COUNTRY_CODE,
     CONF_ENDPOINT,
-    CONF_PASSWORD,
-    CONF_USERNAME,
+    CONF_TERMINAL_ID,
+    CONF_TOKEN_INFO,
+    CONF_USER_CODE,
     DOMAIN,
-    LOGGER,
-    SMARTLIFE_APP,
-    TUYA_COUNTRIES,
+    TUYA_CLIENT_ID,
     TUYA_RESPONSE_CODE,
     TUYA_RESPONSE_MSG,
-    TUYA_RESPONSE_PLATFORM_URL,
+    TUYA_RESPONSE_QR_CODE,
     TUYA_RESPONSE_RESULT,
     TUYA_RESPONSE_SUCCESS,
-    TUYA_SMART_APP,
+    TUYA_SCHEMA,
 )
 
 
-class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
-    """Tuya Config Flow."""
+class TuyaConfigFlow(ConfigFlow, domain=DOMAIN):
+    """Tuya config flow."""
 
-    @staticmethod
-    def _try_login(user_input: dict[str, Any]) -> tuple[dict[Any, Any], dict[str, Any]]:
-        """Try login."""
-        response = {}
+    __user_code: str
+    __qr_code: str
+    __qr_image: str
+    __reauth_entry: ConfigEntry | None = None
 
-        country = [
-            country
-            for country in TUYA_COUNTRIES
-            if country.name == user_input[CONF_COUNTRY_CODE]
-        ][0]
+    def __init__(self) -> None:
+        """Initialize the config flow."""
+        self.__login_control = LoginControl()
 
-        data = {
-            CONF_ENDPOINT: country.endpoint,
-            CONF_AUTH_TYPE: AuthType.CUSTOM,
-            CONF_ACCESS_ID: user_input[CONF_ACCESS_ID],
-            CONF_ACCESS_SECRET: user_input[CONF_ACCESS_SECRET],
-            CONF_USERNAME: user_input[CONF_USERNAME],
-            CONF_PASSWORD: user_input[CONF_PASSWORD],
-            CONF_COUNTRY_CODE: country.country_code,
-        }
-
-        for app_type in ("", TUYA_SMART_APP, SMARTLIFE_APP):
-            data[CONF_APP_TYPE] = app_type
-            if data[CONF_APP_TYPE] == "":
-                data[CONF_AUTH_TYPE] = AuthType.CUSTOM
-            else:
-                data[CONF_AUTH_TYPE] = AuthType.SMART_HOME
-
-            api = TuyaOpenAPI(
-                endpoint=data[CONF_ENDPOINT],
-                access_id=data[CONF_ACCESS_ID],
-                access_secret=data[CONF_ACCESS_SECRET],
-                auth_type=data[CONF_AUTH_TYPE],
-            )
-            api.set_dev_channel("hass")
-
-            response = api.connect(
-                username=data[CONF_USERNAME],
-                password=data[CONF_PASSWORD],
-                country_code=data[CONF_COUNTRY_CODE],
-                schema=data[CONF_APP_TYPE],
-            )
-
-            LOGGER.debug("Response %s", response)
-
-            if response.get(TUYA_RESPONSE_SUCCESS, False):
-                break
-
-        return response, data
-
-    async def async_step_user(self, user_input=None):
+    async def async_step_user(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
         """Step user."""
         errors = {}
         placeholders = {}
 
         if user_input is not None:
-            response, data = await self.hass.async_add_executor_job(
-                self._try_login, user_input
+            success, response = await self.__async_get_qr_code(
+                user_input[CONF_USER_CODE]
             )
+            if success:
+                return await self.async_step_scan()
 
-            if response.get(TUYA_RESPONSE_SUCCESS, False):
-                if endpoint := response.get(TUYA_RESPONSE_RESULT, {}).get(
-                    TUYA_RESPONSE_PLATFORM_URL
-                ):
-                    data[CONF_ENDPOINT] = endpoint
-
-                data[CONF_AUTH_TYPE] = data[CONF_AUTH_TYPE].value
-
-                return self.async_create_entry(
-                    title=user_input[CONF_USERNAME],
-                    data=data,
-                )
             errors["base"] = "login_error"
             placeholders = {
-                TUYA_RESPONSE_CODE: response.get(TUYA_RESPONSE_CODE),
-                TUYA_RESPONSE_MSG: response.get(TUYA_RESPONSE_MSG),
+                TUYA_RESPONSE_MSG: response.get(TUYA_RESPONSE_MSG, "Unknown error"),
+                TUYA_RESPONSE_CODE: response.get(TUYA_RESPONSE_CODE, "0"),
             }
-
-        if user_input is None:
+        else:
             user_input = {}
 
         return self.async_show_form(
@@ -119,27 +67,146 @@ class TuyaConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(
-                        CONF_COUNTRY_CODE,
-                        default=user_input.get(CONF_COUNTRY_CODE, "United States"),
-                    ): vol.In(
-                        # We don't pass a dict {code:name} because country codes can be duplicate.
-                        [country.name for country in TUYA_COUNTRIES]
-                    ),
-                    vol.Required(
-                        CONF_ACCESS_ID, default=user_input.get(CONF_ACCESS_ID, "")
-                    ): str,
-                    vol.Required(
-                        CONF_ACCESS_SECRET,
-                        default=user_input.get(CONF_ACCESS_SECRET, ""),
-                    ): str,
-                    vol.Required(
-                        CONF_USERNAME, default=user_input.get(CONF_USERNAME, "")
-                    ): str,
-                    vol.Required(
-                        CONF_PASSWORD, default=user_input.get(CONF_PASSWORD, "")
+                        CONF_USER_CODE, default=user_input.get(CONF_USER_CODE, "")
                     ): str,
                 }
             ),
             errors=errors,
             description_placeholders=placeholders,
         )
+
+    async def async_step_scan(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Step scan."""
+        if user_input is None:
+            return self.async_show_form(
+                step_id="scan",
+                description_placeholders={
+                    TUYA_RESPONSE_QR_CODE: self.__qr_image,
+                },
+            )
+
+        ret, info = await self.hass.async_add_executor_job(
+            self.__login_control.login_result,
+            self.__qr_code,
+            TUYA_CLIENT_ID,
+            self.__user_code,
+        )
+        if not ret:
+            return self.async_show_form(
+                step_id="scan",
+                errors={"base": "login_error"},
+                description_placeholders={
+                    TUYA_RESPONSE_QR_CODE: self.__qr_image,
+                    TUYA_RESPONSE_MSG: info.get(TUYA_RESPONSE_MSG, "Unknown error"),
+                    TUYA_RESPONSE_CODE: info.get(TUYA_RESPONSE_CODE, 0),
+                },
+            )
+
+        entry_data = {
+            CONF_USER_CODE: self.__user_code,
+            CONF_TOKEN_INFO: {
+                "t": info["t"],
+                "uid": info["uid"],
+                "expire_time": info["expire_time"],
+                "access_token": info["access_token"],
+                "refresh_token": info["refresh_token"],
+            },
+            CONF_TERMINAL_ID: info[CONF_TERMINAL_ID],
+            CONF_ENDPOINT: info[CONF_ENDPOINT],
+        }
+
+        if self.__reauth_entry:
+            return self.async_update_reload_and_abort(
+                self.__reauth_entry,
+                data=entry_data,
+            )
+
+        return self.async_create_entry(
+            title=info.get("username"),
+            data=entry_data,
+        )
+
+    async def async_step_reauth(self, _: Mapping[str, Any]) -> FlowResult:
+        """Handle initiation of re-authentication with Tuya."""
+        self.__reauth_entry = self.hass.config_entries.async_get_entry(
+            self.context["entry_id"]
+        )
+
+        if self.__reauth_entry and CONF_USER_CODE in self.__reauth_entry.data:
+            success, _ = await self.__async_get_qr_code(
+                self.__reauth_entry.data[CONF_USER_CODE]
+            )
+            if success:
+                return await self.async_step_scan()
+
+        return await self.async_step_reauth_user_code()
+
+    async def async_step_reauth_user_code(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle re-authentication with a Tuya."""
+        errors = {}
+        placeholders = {}
+
+        if user_input is not None:
+            success, response = await self.__async_get_qr_code(
+                user_input[CONF_USER_CODE]
+            )
+            if success:
+                return await self.async_step_scan()
+
+            errors["base"] = "login_error"
+            placeholders = {
+                TUYA_RESPONSE_MSG: response.get(TUYA_RESPONSE_MSG, "Unknown error"),
+                TUYA_RESPONSE_CODE: response.get(TUYA_RESPONSE_CODE, "0"),
+            }
+        else:
+            user_input = {}
+
+        return self.async_show_form(
+            step_id="reauth_user_code",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(
+                        CONF_USER_CODE, default=user_input.get(CONF_USER_CODE, "")
+                    ): str,
+                }
+            ),
+            errors=errors,
+            description_placeholders=placeholders,
+        )
+
+    async def __async_get_qr_code(self, user_code: str) -> tuple[bool, dict[str, Any]]:
+        """Get the QR code."""
+        response = await self.hass.async_add_executor_job(
+            self.__login_control.qr_code,
+            TUYA_CLIENT_ID,
+            TUYA_SCHEMA,
+            user_code,
+        )
+        if success := response.get(TUYA_RESPONSE_SUCCESS, False):
+            self.__user_code = user_code
+            self.__qr_code = response[TUYA_RESPONSE_RESULT][TUYA_RESPONSE_QR_CODE]
+            self.__qr_image = _generate_qr_code(self.__qr_code)
+        return success, response
+
+
+def _generate_qr_code(data: str) -> str:
+    """Create an SVG QR code that can be scanned with the Smart Life app."""
+    qr_code = segno.make(f"tuyaSmart--qrLogin?token={data}", error="h")
+    with BytesIO() as buffer:
+        qr_code.save(
+            buffer,
+            kind="svg",
+            border=5,
+            scale=5,
+            xmldecl=False,
+            svgns=False,
+            svgclass=None,
+            lineclass=None,
+            svgversion=2,
+            dark="#1abcf2",
+        )
+        return str(buffer.getvalue().decode("ascii"))

--- a/custom_components/tuya/const.py
+++ b/custom_components/tuya/const.py
@@ -3,11 +3,9 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from enum import StrEnum
 import logging
 
-from tuya_iot import TuyaCloudOpenAPIEndpoint
-
-from homeassistant.backports.enum import StrEnum
 from homeassistant.components.sensor import SensorDeviceClass
 from homeassistant.const import (
     CONCENTRATION_MICROGRAMS_PER_CUBIC_METER,
@@ -31,27 +29,24 @@ from homeassistant.const import (
 DOMAIN = "tuya"
 LOGGER = logging.getLogger(__package__)
 
-CONF_AUTH_TYPE = "auth_type"
-CONF_PROJECT_TYPE = "tuya_project_type"
-CONF_ENDPOINT = "endpoint"
-CONF_ACCESS_ID = "access_id"
-CONF_ACCESS_SECRET = "access_secret"
-CONF_USERNAME = "username"
-CONF_PASSWORD = "password"
-CONF_COUNTRY_CODE = "country_code"
 CONF_APP_TYPE = "tuya_app_type"
+CONF_ENDPOINT = "endpoint"
+CONF_TERMINAL_ID = "terminal_id"
+CONF_TOKEN_INFO = "token_info"
+CONF_USER_CODE = "user_code"
+CONF_USERNAME = "username"
+
+TUYA_CLIENT_ID = "HA_3y9q4ak7g4ephrvke"
+TUYA_SCHEMA = "haauthorize"
 
 TUYA_DISCOVERY_NEW = "tuya_discovery_new"
 TUYA_HA_SIGNAL_UPDATE_ENTITY = "tuya_entry_update"
 
 TUYA_RESPONSE_CODE = "code"
-TUYA_RESPONSE_RESULT = "result"
 TUYA_RESPONSE_MSG = "msg"
+TUYA_RESPONSE_QR_CODE = "qrcode"
+TUYA_RESPONSE_RESULT = "result"
 TUYA_RESPONSE_SUCCESS = "success"
-TUYA_RESPONSE_PLATFORM_URL = "platform_url"
-
-TUYA_SMART_APP = "tuyaSmart"
-SMARTLIFE_APP = "smartlife"
 
 PLATFORMS = [
     Platform.ALARM_CONTROL_PANEL,
@@ -382,6 +377,7 @@ class DPCode(StrEnum):
     TEMP_VALUE_V2 = "temp_value_v2"
     TEMPER_ALARM = "temper_alarm"  # Tamper alarm
     TIME_TOTAL = "time_total"
+    TIME_USE = "time_use"  # Total seconds of irrigation
     TOTAL_CLEAN_AREA = "total_clean_area"
     TOTAL_CLEAN_COUNT = "total_clean_count"
     TOTAL_CLEAN_TIME = "total_clean_time"
@@ -428,6 +424,7 @@ class DPCode(StrEnum):
     WATER_RESET = "water_reset"  # Resetting of water usage days
     WATER_SET = "water_set"  # Water level
     WATERSENSOR_STATE = "watersensor_state"
+    WEATHER_DELAY = "weather_delay"
     WET = "wet"  # Humidification
     WINDOW_CHECK = "window_check"
     WINDOW_STATE = "window_state"
@@ -638,259 +635,3 @@ for uom in UNITS:
         DEVICE_CLASS_UNITS.setdefault(device_class, {})[uom.unit] = uom
         for unit_alias in uom.aliases:
             DEVICE_CLASS_UNITS[device_class][unit_alias] = uom
-
-
-@dataclass
-class Country:
-    """Describe a supported country."""
-
-    name: str
-    country_code: str
-    endpoint: str = TuyaCloudOpenAPIEndpoint.AMERICA
-
-
-# https://developer.tuya.com/en/docs/iot/oem-app-data-center-distributed?id=Kafi0ku9l07qb
-TUYA_COUNTRIES = [
-    Country("Afghanistan", "93", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Albania", "355", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Algeria", "213", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("American Samoa", "1-684", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Andorra", "376", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Angola", "244", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Anguilla", "1-264", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Antarctica", "672", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Antigua and Barbuda", "1-268", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Argentina", "54", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Armenia", "374", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Aruba", "297", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Australia", "61", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Austria", "43", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Azerbaijan", "994", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bahamas", "1-242", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bahrain", "973", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bangladesh", "880", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Barbados", "1-246", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Belarus", "375", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Belgium", "32", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Belize", "501", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Benin", "229", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bermuda", "1-441", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bhutan", "975", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bolivia", "591", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Bosnia and Herzegovina", "387", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Botswana", "267", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Brazil", "55", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("British Indian Ocean Territory", "246", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("British Virgin Islands", "1-284", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Brunei", "673", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Bulgaria", "359", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Burkina Faso", "226", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Burundi", "257", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Cambodia", "855", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Cameroon", "237", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Canada", "1", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Capo Verde", "238", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Cayman Islands", "1-345", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Central African Republic", "236", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Chad", "235", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Chile", "56", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("China", "86", TuyaCloudOpenAPIEndpoint.CHINA),
-    Country("Christmas Island", "61"),
-    Country("Cocos Islands", "61"),
-    Country("Colombia", "57", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Comoros", "269", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Cook Islands", "682", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Costa Rica", "506", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Croatia", "385", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Cuba", "53"),
-    Country("Curacao", "599", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Cyprus", "357", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Czech Republic", "420", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Democratic Republic of the Congo", "243", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Denmark", "45", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Djibouti", "253", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Dominica", "1-767", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Dominican Republic", "1-809", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("East Timor", "670", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Ecuador", "593", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Egypt", "20", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("El Salvador", "503", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Equatorial Guinea", "240", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Eritrea", "291", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Estonia", "372", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Ethiopia", "251", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Falkland Islands", "500", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Faroe Islands", "298", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Fiji", "679", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Finland", "358", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("France", "33", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("French Polynesia", "689", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Gabon", "241", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Gambia", "220", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Georgia", "995", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Germany", "49", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Ghana", "233", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Gibraltar", "350", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Greece", "30", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Greenland", "299", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Grenada", "1-473", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Guam", "1-671", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Guatemala", "502", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Guernsey", "44-1481"),
-    Country("Guinea", "224"),
-    Country("Guinea-Bissau", "245", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Guyana", "592", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Haiti", "509", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Honduras", "504", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Hong Kong", "852", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Hungary", "36", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Iceland", "354", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("India", "91", TuyaCloudOpenAPIEndpoint.INDIA),
-    Country("Indonesia", "62", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Iran", "98"),
-    Country("Iraq", "964", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Ireland", "353", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Isle of Man", "44-1624"),
-    Country("Israel", "972", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Italy", "39", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Ivory Coast", "225", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Jamaica", "1-876", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Japan", "81", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Jersey", "44-1534"),
-    Country("Jordan", "962", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Kazakhstan", "7", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Kenya", "254", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Kiribati", "686", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Kosovo", "383"),
-    Country("Kuwait", "965", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Kyrgyzstan", "996", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Laos", "856", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Latvia", "371", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Lebanon", "961", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Lesotho", "266", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Liberia", "231", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Libya", "218", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Liechtenstein", "423", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Lithuania", "370", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Luxembourg", "352", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Macao", "853", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Macedonia", "389", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Madagascar", "261", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Malawi", "265", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Malaysia", "60", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Maldives", "960", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mali", "223", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Malta", "356", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Marshall Islands", "692", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mauritania", "222", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mauritius", "230", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mayotte", "262", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mexico", "52", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Micronesia", "691", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Moldova", "373", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Monaco", "377", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mongolia", "976", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Montenegro", "382", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Montserrat", "1-664", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Morocco", "212", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Mozambique", "258", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Myanmar", "95", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Namibia", "264", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Nauru", "674", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Nepal", "977", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Netherlands", "31", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Netherlands Antilles", "599"),
-    Country("New Caledonia", "687", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("New Zealand", "64", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Nicaragua", "505", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Niger", "227", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Nigeria", "234", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Niue", "683", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("North Korea", "850"),
-    Country("Northern Mariana Islands", "1-670", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Norway", "47", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Oman", "968", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Pakistan", "92", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Palau", "680", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Palestine", "970", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Panama", "507", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Papua New Guinea", "675", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Paraguay", "595", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Peru", "51", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Philippines", "63", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Pitcairn", "64"),
-    Country("Poland", "48", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Portugal", "351", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Puerto Rico", "1-787, 1-939", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Qatar", "974", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Republic of the Congo", "242", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Reunion", "262", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Romania", "40", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Russia", "7", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Rwanda", "250", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Saint Barthelemy", "590", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Saint Helena", "290"),
-    Country("Saint Kitts and Nevis", "1-869", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Saint Lucia", "1-758", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Saint Martin", "590", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Saint Pierre and Miquelon", "508", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country(
-        "Saint Vincent and the Grenadines", "1-784", TuyaCloudOpenAPIEndpoint.EUROPE
-    ),
-    Country("Samoa", "685", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("San Marino", "378", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Sao Tome and Principe", "239", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Saudi Arabia", "966", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Senegal", "221", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Serbia", "381", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Seychelles", "248", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Sierra Leone", "232", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Singapore", "65", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Sint Maarten", "1-721", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Slovakia", "421", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Slovenia", "386", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Solomon Islands", "677", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Somalia", "252", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("South Africa", "27", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("South Korea", "82", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("South Sudan", "211"),
-    Country("Spain", "34", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Sri Lanka", "94", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Sudan", "249"),
-    Country("Suriname", "597", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Svalbard and Jan Mayen", "4779", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Swaziland", "268", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Sweden", "46", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Switzerland", "41", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Syria", "963"),
-    Country("Taiwan", "886", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Tajikistan", "992", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Tanzania", "255", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Thailand", "66", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Togo", "228", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Tokelau", "690", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Tonga", "676", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Trinidad and Tobago", "1-868", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Tunisia", "216", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Turkey", "90", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Turkmenistan", "993", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Turks and Caicos Islands", "1-649", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Tuvalu", "688", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("U.S. Virgin Islands", "1-340", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Uganda", "256", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Ukraine", "380", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("United Arab Emirates", "971", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("United Kingdom", "44", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("United States", "1", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Uruguay", "598", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Uzbekistan", "998", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Vanuatu", "678", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Vatican", "379", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Venezuela", "58", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Vietnam", "84", TuyaCloudOpenAPIEndpoint.AMERICA),
-    Country("Wallis and Futuna", "681", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Western Sahara", "212", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Yemen", "967", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Zambia", "260", TuyaCloudOpenAPIEndpoint.EUROPE),
-    Country("Zimbabwe", "263", TuyaCloudOpenAPIEndpoint.EUROPE),
-]

--- a/custom_components/tuya/diagnostics.py
+++ b/custom_components/tuya/diagnostics.py
@@ -5,7 +5,7 @@ from contextlib import suppress
 import json
 from typing import Any, cast
 
-from tuya_iot import TuyaDevice
+from tuya_sharing import CustomerDevice
 
 from homeassistant.components.diagnostics import REDACTED
 from homeassistant.config_entries import ConfigEntry
@@ -15,14 +15,7 @@ from homeassistant.helpers.device_registry import DeviceEntry
 from homeassistant.util import dt as dt_util
 
 from . import HomeAssistantTuyaData
-from .const import (
-    CONF_APP_TYPE,
-    CONF_AUTH_TYPE,
-    CONF_COUNTRY_CODE,
-    CONF_ENDPOINT,
-    DOMAIN,
-    DPCode,
-)
+from .const import DOMAIN, DPCode
 
 
 async def async_get_config_entry_diagnostics(
@@ -49,14 +42,12 @@ def _async_get_diagnostics(
     hass_data: HomeAssistantTuyaData = hass.data[DOMAIN][entry.entry_id]
 
     mqtt_connected = None
-    if hass_data.home_manager.mq.client:
-        mqtt_connected = hass_data.home_manager.mq.client.is_connected()
+    if hass_data.manager.mq.client:
+        mqtt_connected = hass_data.manager.mq.client.is_connected()
 
     data = {
-        "endpoint": entry.data[CONF_ENDPOINT],
-        "auth_type": entry.data[CONF_AUTH_TYPE],
-        "country_code": entry.data[CONF_COUNTRY_CODE],
-        "app_type": entry.data[CONF_APP_TYPE],
+        "endpoint": hass_data.manager.customer_api.endpoint,
+        "terminal_id": hass_data.manager.terminal_id,
         "mqtt_connected": mqtt_connected,
         "disabled_by": entry.disabled_by,
         "disabled_polling": entry.pref_disable_polling,
@@ -65,13 +56,13 @@ def _async_get_diagnostics(
     if device:
         tuya_device_id = next(iter(device.identifiers))[1]
         data |= _async_device_as_dict(
-            hass, hass_data.device_manager.device_map[tuya_device_id]
+            hass, hass_data.manager.device_map[tuya_device_id]
         )
     else:
         data.update(
             devices=[
                 _async_device_as_dict(hass, device)
-                for device in hass_data.device_manager.device_map.values()
+                for device in hass_data.manager.device_map.values()
             ]
         )
 
@@ -79,13 +70,15 @@ def _async_get_diagnostics(
 
 
 @callback
-def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, Any]:
+def _async_device_as_dict(
+    hass: HomeAssistant, device: CustomerDevice
+) -> dict[str, Any]:
     """Represent a Tuya device as a dictionary."""
 
     # Base device information, without sensitive information.
     data = {
+        "id": device.id,
         "name": device.name,
-        "model": device.model if hasattr(device, "model") else None,
         "category": device.category,
         "product_id": device.product_id,
         "product_name": device.product_name,
@@ -99,6 +92,8 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
         "status_range": {},
         "status": {},
         "home_assistant": {},
+        "set_up": device.set_up,
+        "support_local": device.support_local,
     }
 
     # Gather Tuya states
@@ -155,7 +150,7 @@ def _async_device_as_dict(hass: HomeAssistant, device: TuyaDevice) -> dict[str, 
 
         for entity_entry in hass_entities:
             state = hass.states.get(entity_entry.entity_id)
-            state_dict = None
+            state_dict: dict[str, Any] | None = None
             if state:
                 state_dict = dict(state.as_dict())
 

--- a/custom_components/tuya/fan.py
+++ b/custom_components/tuya/fan.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,
@@ -44,12 +44,12 @@ async def async_setup_entry(
         """Discover and add a discovered tuya fan."""
         entities: list[TuyaFanEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if device and device.category in TUYA_SUPPORT_TYPE:
-                entities.append(TuyaFanEntity(device, hass_data.device_manager))
+                entities.append(TuyaFanEntity(device, hass_data.manager))
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -65,11 +65,12 @@ class TuyaFanEntity(TuyaEntity, FanEntity):
     _speed: IntegerTypeData | None = None
     _speeds: EnumTypeData | None = None
     _switch: DPCode | None = None
+    _attr_name = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
     ) -> None:
         """Init Tuya Fan Device."""
         super().__init__(device, device_manager)

--- a/custom_components/tuya/humidifier.py
+++ b/custom_components/tuya/humidifier.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.humidifier import (
     HumidifierDeviceClass,
@@ -21,13 +21,14 @@ from .base import IntegerTypeData, TuyaEntity
 from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, DPType
 
 
-@dataclass
+@dataclass(frozen=True)
 class TuyaHumidifierEntityDescription(HumidifierEntityDescription):
     """Describe an Tuya (de)humidifier entity."""
 
     # DPCode, to use. If None, the key will be used as DPCode
     dpcode: DPCode | tuple[DPCode, ...] | None = None
 
+    current_humidity: DPCode | None = None
     humidity: DPCode | None = None
 
 
@@ -37,6 +38,7 @@ HUMIDIFIERS: dict[str, TuyaHumidifierEntityDescription] = {
     "cs": TuyaHumidifierEntityDescription(
         key=DPCode.SWITCH,
         dpcode=(DPCode.SWITCH, DPCode.SWITCH_SPRAY),
+        current_humidity=DPCode.HUMIDITY_INDOOR,
         humidity=DPCode.DEHUMIDITY_SET_VALUE,
         device_class=HumidifierDeviceClass.DEHUMIDIFIER,
     ),
@@ -45,6 +47,7 @@ HUMIDIFIERS: dict[str, TuyaHumidifierEntityDescription] = {
     "jsq": TuyaHumidifierEntityDescription(
         key=DPCode.SWITCH,
         dpcode=(DPCode.SWITCH, DPCode.SWITCH_SPRAY),
+        current_humidity=DPCode.HUMIDITY_CURRENT,
         humidity=DPCode.HUMIDITY_SET,
         device_class=HumidifierDeviceClass.HUMIDIFIER,
     ),
@@ -62,14 +65,14 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya (de)humidifier."""
         entities: list[TuyaHumidifierEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if description := HUMIDIFIERS.get(device.category):
                 entities.append(
-                    TuyaHumidifierEntity(device, hass_data.device_manager, description)
+                    TuyaHumidifierEntity(device, hass_data.manager, description)
                 )
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -79,17 +82,19 @@ async def async_setup_entry(
 class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
     """Tuya (de)humidifier Device."""
 
+    _current_humidity: IntegerTypeData | None = None
     _set_humidity: IntegerTypeData | None = None
     _switch_dpcode: DPCode | None = None
     entity_description: TuyaHumidifierEntityDescription
+    _attr_name = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: TuyaHumidifierEntityDescription,
     ) -> None:
-        """Init Tuya (de)humidier."""
+        """Init Tuya (de)humidifier."""
         super().__init__(device, device_manager)
         self.entity_description = description
         self._attr_unique_id = f"{super().unique_id}{description.key}"
@@ -106,6 +111,13 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
             self._set_humidity = int_type
             self._attr_min_humidity = int(int_type.min_scaled)
             self._attr_max_humidity = int(int_type.max_scaled)
+
+        # Determine current humidity DPCode
+        if int_type := self.find_dpcode(
+            description.current_humidity,
+            dptype=DPType.INTEGER,
+        ):
+            self._current_humidity = int_type
 
         # Determine mode support and provided modes
         if enum_type := self.find_dpcode(
@@ -137,6 +149,19 @@ class TuyaHumidifierEntity(TuyaEntity, HumidifierEntity):
             return None
 
         return round(self._set_humidity.scale_value(humidity))
+
+    @property
+    def current_humidity(self) -> int | None:
+        """Return the current humidity."""
+        if self._current_humidity is None:
+            return None
+
+        if (
+            current_humidity := self.device.status.get(self._current_humidity.dpcode)
+        ) is None:
+            return None
+
+        return round(self._current_humidity.scale_value(current_humidity))
 
     def turn_on(self, **kwargs):
         """Turn the device on."""

--- a/custom_components/tuya/light.py
+++ b/custom_components/tuya/light.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass, field
 import json
 from typing import Any, cast
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS,
@@ -49,7 +49,7 @@ DEFAULT_COLOR_TYPE_DATA_V2 = ColorTypeData(
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class TuyaLightEntityDescription(LightEntityDescription):
     """Describe an Tuya light entity."""
 
@@ -70,7 +70,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "clkg": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_BACKLIGHT,
-            name="Backlight",
+            translation_key="backlight",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -79,6 +79,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "dc": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -90,6 +91,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "dd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -102,6 +104,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "dj": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=(DPCode.BRIGHT_VALUE_V2, DPCode.BRIGHT_VALUE),
             color_temp=(DPCode.TEMP_VALUE_V2, DPCode.TEMP_VALUE),
@@ -111,8 +114,20 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
         # Based on multiple reports: manufacturer customized Dimmer 2 switches
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Light",
+            translation_key="light",
             brightness=DPCode.BRIGHT_VALUE_1,
+        ),
+    ),
+    # Filament Light
+    # Based on data from https://github.com/home-assistant/core/issues/106703
+    # Product category mentioned in https://developer.tuya.com/en/docs/iot/oemapp-light?id=Kb77kja5woao6
+    # As at 30/12/23 not documented in https://developer.tuya.com/en/docs/iot/lighting?id=Kaiuyzxq30wmc
+    "dsd": (
+        TuyaLightEntityDescription(
+            key=DPCode.SWITCH_LED,
+            name=None,
+            color_mode=DPCode.WORK_MODE,
+            brightness=DPCode.BRIGHT_VALUE,
         ),
     ),
     # Ceiling Fan Light
@@ -120,6 +135,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "fsd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -128,6 +144,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
         # Some ceiling fan lights use LIGHT for DPCode instead of SWITCH_LED
         TuyaLightEntityDescription(
             key=DPCode.LIGHT,
+            name=None,
         ),
     ),
     # Ambient Light
@@ -135,6 +152,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "fwd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -146,6 +164,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "gyd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -157,6 +176,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "jsq": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_data=DPCode.COLOUR_DATA_HSV,
@@ -167,7 +187,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "kg": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_BACKLIGHT,
-            name="Backlight",
+            translation_key="backlight",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -176,7 +196,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "kj": (
         TuyaLightEntityDescription(
             key=DPCode.LIGHT,
-            name="Backlight",
+            translation_key="backlight",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -185,7 +205,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "kt": (
         TuyaLightEntityDescription(
             key=DPCode.LIGHT,
-            name="Backlight",
+            translation_key="backlight",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -195,6 +215,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "mbd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_data=DPCode.COLOUR_DATA,
@@ -206,6 +227,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "qjdcz": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_data=DPCode.COLOUR_DATA,
@@ -216,7 +238,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "qn": (
         TuyaLightEntityDescription(
             key=DPCode.LIGHT,
-            name="Backlight",
+            translation_key="backlight",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -239,21 +261,21 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "tgkg": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED_1,
-            name="Light",
+            translation_key="light",
             brightness=DPCode.BRIGHT_VALUE_1,
             brightness_max=DPCode.BRIGHTNESS_MAX_1,
             brightness_min=DPCode.BRIGHTNESS_MIN_1,
         ),
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED_2,
-            name="Light 2",
+            translation_key="light_2",
             brightness=DPCode.BRIGHT_VALUE_2,
             brightness_max=DPCode.BRIGHTNESS_MAX_2,
             brightness_min=DPCode.BRIGHTNESS_MIN_2,
         ),
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED_3,
-            name="Light 3",
+            translation_key="light_3",
             brightness=DPCode.BRIGHT_VALUE_3,
             brightness_max=DPCode.BRIGHTNESS_MAX_3,
             brightness_min=DPCode.BRIGHTNESS_MIN_3,
@@ -264,19 +286,19 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "tgq": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
-            name="Light",
+            translation_key="light",
             brightness=(DPCode.BRIGHT_VALUE_V2, DPCode.BRIGHT_VALUE),
             brightness_max=DPCode.BRIGHTNESS_MAX_1,
             brightness_min=DPCode.BRIGHTNESS_MIN_1,
         ),
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED_1,
-            name="Light",
+            translation_key="light",
             brightness=DPCode.BRIGHT_VALUE_1,
         ),
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED_2,
-            name="Light 2",
+            translation_key="light_2",
             brightness=DPCode.BRIGHT_VALUE_2,
         ),
     ),
@@ -285,7 +307,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "hxd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
-            name="Light",
+            translation_key="light",
             brightness=(DPCode.BRIGHT_VALUE_V2, DPCode.BRIGHT_VALUE),
             brightness_max=DPCode.BRIGHTNESS_MAX_1,
             brightness_min=DPCode.BRIGHTNESS_MIN_1,
@@ -296,6 +318,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "tyndj": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -307,6 +330,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "xdd": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_LED,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
@@ -314,7 +338,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
         ),
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_NIGHT_LIGHT,
-            name="Night light",
+            translation_key="night_light",
         ),
     ),
     # Remote Control
@@ -322,6 +346,7 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "ykq": (
         TuyaLightEntityDescription(
             key=DPCode.SWITCH_CONTROLLER,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_CONTROLLER,
             color_temp=DPCode.TEMP_CONTROLLER,
@@ -332,9 +357,15 @@ LIGHTS: dict[str, tuple[TuyaLightEntityDescription, ...]] = {
     "fs": (
         TuyaLightEntityDescription(
             key=DPCode.LIGHT,
+            name=None,
             color_mode=DPCode.WORK_MODE,
             brightness=DPCode.BRIGHT_VALUE,
             color_temp=DPCode.TEMP_VALUE,
+        ),
+        TuyaLightEntityDescription(
+            key=DPCode.SWITCH_LED,
+            translation_key="light_2",
+            brightness=DPCode.BRIGHT_VALUE_1,
         ),
     ),
 }
@@ -382,19 +413,17 @@ async def async_setup_entry(
         """Discover and add a discovered tuya light."""
         entities: list[TuyaLightEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := LIGHTS.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaLightEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaLightEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -416,8 +445,8 @@ class TuyaLightEntity(TuyaEntity, LightEntity):
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: TuyaLightEntityDescription,
     ) -> None:
         """Init TuyaHaLight."""

--- a/custom_components/tuya/manifest.json
+++ b/custom_components/tuya/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "tuya",
   "name": "Tuya",
-  "codeowners": ["@Tuya", "@zlinoliver", "@METISU", "@frenck", "@dougiteixeira"],
+  "codeowners": ["@Tuya", "@zlinoliver", "@frenck"],
   "config_flow": true,
   "dependencies": ["ffmpeg"],
   "dhcp": [
@@ -43,6 +43,5 @@
   "integration_type": "hub",
   "iot_class": "cloud_push",
   "loggers": ["tuya_iot"],
-  "requirements": ["tuya-iot-py-sdk==0.6.6"],
-  "version": "11062023.001"
+  "requirements": ["tuya-device-sharing-sdk==0.1.9", "segno==1.5.3"]
 }

--- a/custom_components/tuya/number.py
+++ b/custom_components/tuya/number.py
@@ -1,7 +1,7 @@
 """Support for Tuya number."""
 from __future__ import annotations
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.number import (
     NumberDeviceClass,
@@ -27,7 +27,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "dgnbj": (
         NumberEntityDescription(
             key=DPCode.ALARM_TIME,
-            name="Time",
+            translation_key="time",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -36,35 +36,35 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "bh": (
         NumberEntityDescription(
             key=DPCode.TEMP_SET,
-            name="Temperature",
+            translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_SET_F,
-            name="Temperature",
+            translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_BOILING_C,
-            name="Temperature after boiling",
+            translation_key="temperature_after_boiling",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_BOILING_F,
-            name="Temperature after boiling",
+            translation_key="temperature_after_boiling",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.WARM_TIME,
-            name="Heat preservation time",
+            translation_key="heat_preservation_time",
             icon="mdi:timer",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -74,12 +74,12 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "cwwsq": (
         NumberEntityDescription(
             key=DPCode.MANUAL_FEED,
-            name="Feed",
+            translation_key="feed",
             icon="mdi:bowl",
         ),
         NumberEntityDescription(
             key=DPCode.VOICE_TIMES,
-            name="Voice times",
+            translation_key="voice_times",
             icon="mdi:microphone",
         ),
     ),
@@ -88,18 +88,18 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "hps": (
         NumberEntityDescription(
             key=DPCode.SENSITIVITY,
-            name="Sensitivity",
+            translation_key="sensitivity",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.NEAR_DETECTION,
-            name="Near detection",
+            translation_key="near_detection",
             icon="mdi:signal-distance-variant",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.FAR_DETECTION,
-            name="Far detection",
+            translation_key="far_detection",
             icon="mdi:signal-distance-variant",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -109,26 +109,26 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "kfj": (
         NumberEntityDescription(
             key=DPCode.WATER_SET,
-            name="Water level",
+            translation_key="water_level",
             icon="mdi:cup-water",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_SET,
-            name="Temperature",
+            translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.WARM_TIME,
-            name="Heat preservation time",
+            translation_key="heat_preservation_time",
             icon="mdi:timer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.POWDER_SET,
-            name="Powder",
+            translation_key="powder",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -137,27 +137,27 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "ms": (
         NumberEntityDescription(
             key=DPCode.AUTO_LOCK_TIME,
-            name="Auto lock time",
             icon="mdi:timer-cog-outline",
             native_unit_of_measurement=UnitOfTime.SECONDS,
+            translation_key="lock_time_auto",
         ),
         NumberEntityDescription(
             key=DPCode.STAY_HOLD_TIME,
-            name="Loitering hold time",
             icon="mdi:timer-cog-outline",
             native_unit_of_measurement=UnitOfTime.SECONDS,
+            translation_key="lock_stay_hold_time",
         ),
         NumberEntityDescription(
             key=DPCode.OPEN_RATE,
-            name="Opening percentage",
             icon="mdi:percent",
             native_unit_of_measurement=PERCENTAGE,
+            translation_key="lock_open_rate",
         ),
         NumberEntityDescription(
             key=DPCode.ALARM_TIME,
-            name="Alert duration",
             icon="mdi:timer-cog-outline",
             native_unit_of_measurement=UnitOfTime.SECONDS,
+            translation_key="lock_alarm_time",
         ),
     ),
     # Sous Vide Cooker
@@ -165,20 +165,20 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "mzj": (
         NumberEntityDescription(
             key=DPCode.COOK_TEMPERATURE,
-            name="Cook temperature",
+            translation_key="cook_temperature",
             icon="mdi:thermometer",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.COOK_TIME,
-            name="Cook time",
+            translation_key="cook_time",
             icon="mdi:timer",
             native_unit_of_measurement=UnitOfTime.MINUTES,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.CLOUD_RECIPE_NUMBER,
-            name="Cloud recipe",
+            translation_key="cloud_recipe",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -187,7 +187,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "sd": (
         NumberEntityDescription(
             key=DPCode.VOLUME_SET,
-            name="Volume",
+            translation_key="volume",
             icon="mdi:volume-high",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -197,7 +197,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "sgbj": (
         NumberEntityDescription(
             key=DPCode.ALARM_TIME,
-            name="Time",
+            translation_key="time",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -206,7 +206,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "sp": (
         NumberEntityDescription(
             key=DPCode.BASIC_DEVICE_VOLUME,
-            name="Volume",
+            translation_key="volume",
             icon="mdi:volume-high",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -216,37 +216,37 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "tgkg": (
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MIN_1,
-            name="Minimum brightness",
+            translation_key="minimum_brightness",
             icon="mdi:lightbulb-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_1,
-            name="Maximum brightness",
+            translation_key="maximum_brightness",
             icon="mdi:lightbulb-on-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MIN_2,
-            name="Minimum brightness 2",
+            translation_key="minimum_brightness_2",
             icon="mdi:lightbulb-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_2,
-            name="Maximum brightness 2",
+            translation_key="maximum_brightness_2",
             icon="mdi:lightbulb-on-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MIN_3,
-            name="Minimum brightness 3",
+            translation_key="minimum_brightness_3",
             icon="mdi:lightbulb-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_3,
-            name="Maximum brightness 3",
+            translation_key="maximum_brightness_3",
             icon="mdi:lightbulb-on-outline",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -256,25 +256,25 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "tgq": (
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MIN_1,
-            name="Minimum brightness",
+            translation_key="minimum_brightness",
             icon="mdi:lightbulb-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_1,
-            name="Maximum brightness",
+            translation_key="maximum_brightness",
             icon="mdi:lightbulb-on-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MIN_2,
-            name="Minimum brightness 2",
+            translation_key="minimum_brightness_2",
             icon="mdi:lightbulb-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.BRIGHTNESS_MAX_2,
-            name="Maximum brightness 2",
+            translation_key="maximum_brightness_2",
             icon="mdi:lightbulb-on-outline",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -284,7 +284,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "zd": (
         NumberEntityDescription(
             key=DPCode.SENSITIVITY,
-            name="Sensitivity",
+            translation_key="sensitivity",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -292,19 +292,21 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "szjqr": (
         NumberEntityDescription(
             key=DPCode.ARM_DOWN_PERCENT,
-            name="Move down %",
+            translation_key="move_down",
             icon="mdi:arrow-down-bold",
+            native_unit_of_measurement=PERCENTAGE,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.ARM_UP_PERCENT,
-            name="Move up %",
+            translation_key="move_up",
             icon="mdi:arrow-up-bold",
+            native_unit_of_measurement=PERCENTAGE,
             entity_category=EntityCategory.CONFIG,
         ),
         NumberEntityDescription(
             key=DPCode.CLICK_SUSTAIN_TIME,
-            name="Down delay",
+            translation_key="down_delay",
             icon="mdi:timer",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -314,7 +316,7 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "fs": (
         NumberEntityDescription(
             key=DPCode.TEMP,
-            name="Temperature",
+            translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer-lines",
         ),
@@ -324,13 +326,13 @@ NUMBERS: dict[str, tuple[NumberEntityDescription, ...]] = {
     "jsq": (
         NumberEntityDescription(
             key=DPCode.TEMP_SET,
-            name="Temperature",
+            translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer-lines",
         ),
         NumberEntityDescription(
             key=DPCode.TEMP_SET_F,
-            name="Temperature",
+            translation_key="temperature",
             device_class=NumberDeviceClass.TEMPERATURE,
             icon="mdi:thermometer-lines",
         ),
@@ -361,19 +363,17 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya number."""
         entities: list[TuyaNumberEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := NUMBERS.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaNumberEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaNumberEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -387,8 +387,8 @@ class TuyaNumberEntity(TuyaEntity, NumberEntity):
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: NumberEntityDescription,
     ) -> None:
         """Init Tuya sensor."""

--- a/custom_components/tuya/scene.py
+++ b/custom_components/tuya/scene.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_iot import TuyaHomeManager, TuyaScene
+from tuya_sharing import Manager, SharingScene
 
 from homeassistant.components.scene import Scene
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import HomeAssistantTuyaData
@@ -20,28 +20,23 @@ async def async_setup_entry(
 ) -> None:
     """Set up Tuya scenes."""
     hass_data: HomeAssistantTuyaData = hass.data[DOMAIN][entry.entry_id]
-    scenes = await hass.async_add_executor_job(hass_data.home_manager.query_scenes)
-    async_add_entities(
-        TuyaSceneEntity(hass_data.home_manager, scene) for scene in scenes
-    )
+    scenes = await hass.async_add_executor_job(hass_data.manager.query_scenes)
+    async_add_entities(TuyaSceneEntity(hass_data.manager, scene) for scene in scenes)
 
 
 class TuyaSceneEntity(Scene):
     """Tuya Scene Remote."""
 
     _should_poll = False
+    _attr_has_entity_name = True
+    _attr_name = None
 
-    def __init__(self, home_manager: TuyaHomeManager, scene: TuyaScene) -> None:
+    def __init__(self, home_manager: Manager, scene: SharingScene) -> None:
         """Init Tuya Scene."""
         super().__init__()
         self._attr_unique_id = f"tys{scene.scene_id}"
         self.home_manager = home_manager
         self.scene = scene
-
-    @property
-    def name(self) -> str | None:
-        """Return Tuya scene name."""
-        return self.scene.name
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/tuya/select.py
+++ b/custom_components/tuya/select.py
@@ -1,7 +1,7 @@
 """Support for Tuya select."""
 from __future__ import annotations
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
 from homeassistant.config_entries import ConfigEntry
@@ -18,7 +18,6 @@ from .const import DOMAIN, TUYA_DISCOVERY_NEW, DPCode, DPType
 LANGUAGE_SELECT: tuple[SelectEntityDescription, ...] = (
     SelectEntityDescription(
         key=DPCode.LANGUAGE,
-        name="Language",
         entity_category=EntityCategory.CONFIG,
         icon="mdi:translate",
         entity_registry_enabled_default=False,
@@ -36,7 +35,7 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "dgnbj": (
         SelectEntityDescription(
             key=DPCode.ALARM_VOLUME,
-            name="Volume",
+            translation_key="volume",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -45,23 +44,23 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "kfj": (
         SelectEntityDescription(
             key=DPCode.CUP_NUMBER,
-            name="Cups",
+            translation_key="cups",
             icon="mdi:numeric",
         ),
         SelectEntityDescription(
             key=DPCode.CONCENTRATION_SET,
-            name="Concentration",
+            translation_key="concentration",
             icon="mdi:altimeter",
             entity_category=EntityCategory.CONFIG,
         ),
         SelectEntityDescription(
             key=DPCode.MATERIAL,
-            name="Material",
+            translation_key="material",
             entity_category=EntityCategory.CONFIG,
         ),
         SelectEntityDescription(
             key=DPCode.MODE,
-            name="Mode",
+            translation_key="mode",
             icon="mdi:coffee",
         ),
     ),
@@ -70,13 +69,11 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "kg": (
         SelectEntityDescription(
             key=DPCode.RELAY_STATUS,
-            name="Power on behavior",
             entity_category=EntityCategory.CONFIG,
             translation_key="relay_status",
         ),
         SelectEntityDescription(
             key=DPCode.LIGHT_MODE,
-            name="Indicator light mode",
             entity_category=EntityCategory.CONFIG,
             translation_key="light_mode",
         ),
@@ -86,126 +83,108 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "ms": (
         SelectEntityDescription(
             key=DPCode.ALARM_VOLUME,
-            name="Alert volume",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:volume-high",
             translation_key="lock_alarm_volume",
         ),
         SelectEntityDescription(
             key=DPCode.BASIC_NIGHTVISION,
-            name="Infrared (IR) night vision",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:weather-night",
             translation_key="lock_basic_nightvision",
         ),
         SelectEntityDescription(
             key=DPCode.BEEP_VOLUME,
-            name="Local voice volume",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:volume-high",
-            translation_key="lock_doorbell_volume",
+            translation_key="lock_voice_volume",
         ),
         SelectEntityDescription(
             key=DPCode.DOOR_UNCLOSED_TRIGGER,
-            name="Trigger time of unclosed",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="lock_door_unclosed_trigger",
         ),
         SelectEntityDescription(
             key=DPCode.DOORBELL_SONG,
-            name="Doorbell ringtone",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:music-box-multiple-outline",
             translation_key="lock_doorbell_song",
         ),
         SelectEntityDescription(
             key=DPCode.DOORBELL_VOLUME,
-            name="Doorbell volume",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:volume-high",
             translation_key="lock_doorbell_volume",
         ),
         SelectEntityDescription(
             key=DPCode.KEY_TONE,
-            name="Volume on keypress",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:music-box-multiple-outline",
-            translation_key="lock_doorbell_volume",
+            translation_key="lock_keypress_volume",
         ),
         SelectEntityDescription(
             key=DPCode.LOCK_MOTOR_DIRECTION,
-            name="Rotation direction of motor",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:swap-horizontal",
             translation_key="lock_motor_direction",
         ),
         SelectEntityDescription(
             key=DPCode.LOW_POWER_THRESHOLD,
-            name="Low battery alert",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:battery-alert-variant-outline",
             translation_key="lock_low_power_threshold",
         ),
         SelectEntityDescription(
             key=DPCode.MOTOR_TORQUE,
-            name="Torque force of motor",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:hexagon-multiple-outline",
             translation_key="lock_motor_torque",
         ),
         SelectEntityDescription(
             key=DPCode.OPEN_SPEED_STATE,
-            name="Unlocking speed",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:speedometer",
             translation_key="lock_open_speed_state",
         ),
         SelectEntityDescription(
             key=DPCode.PHOTO_MODE,
-            name="Photo mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:image-multiple-outline",
             translation_key="lock_photo_mode",
         ),
         SelectEntityDescription(
             key=DPCode.RINGTONE,
-            name="Local ringtone",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:music-box-multiple-outline",
             translation_key="lock_ringtone",
         ),
         SelectEntityDescription(
             key=DPCode.SOUND_MODE,
-            name="Sound mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:music-box-multiple-outline",
             translation_key="lock_sound_mode",
         ),
         SelectEntityDescription(
             key=DPCode.STAY_ALARM_MODE,
-            name="Loitering alert mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:star-box-multiple-outline",
             translation_key="lock_stay_alarm_mode",
         ),
         SelectEntityDescription(
             key=DPCode.STAY_CAPTURE_MODE,
-            name="Loitering photo capture mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:image-multiple-outline",
             translation_key="lock_stay_capture_mode",
         ),
         SelectEntityDescription(
             key=DPCode.STAY_TRIGGER_DISTANCE,
-            name="Loitering sensing range",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:signal-distance-variant",
             translation_key="lock_stay_trigger_distance",
         ),
         SelectEntityDescription(
             key=DPCode.UNLOCK_SWITCH,
-            name="Unlock mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:shield-lock-open-outline",
             translation_key="lock_unlock_switch",
@@ -217,8 +196,18 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "qn": (
         SelectEntityDescription(
             key=DPCode.LEVEL,
-            name="Temperature level",
+            translation_key="temperature_level",
             icon="mdi:thermometer-lines",
+        ),
+    ),
+    # Smart Water Timer
+    "sfkzq": (
+        # Irrigation will not be run within this set delay period
+        SelectEntityDescription(
+            key=DPCode.WEATHER_DELAY,
+            translation_key="weather_delay",
+            icon="mdi:weather-cloudy-clock",
+            entity_category=EntityCategory.CONFIG,
         ),
     ),
     # Siren Alarm
@@ -226,12 +215,12 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "sgbj": (
         SelectEntityDescription(
             key=DPCode.ALARM_VOLUME,
-            name="Volume",
+            translation_key="volume",
             entity_category=EntityCategory.CONFIG,
         ),
         SelectEntityDescription(
             key=DPCode.BRIGHT_STATE,
-            name="Brightness",
+            translation_key="brightness",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -240,41 +229,35 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "sp": (
         SelectEntityDescription(
             key=DPCode.IPC_WORK_MODE,
-            name="IPC mode",
             entity_category=EntityCategory.CONFIG,
             translation_key="ipc_work_mode",
         ),
         SelectEntityDescription(
             key=DPCode.DECIBEL_SENSITIVITY,
-            name="Sound detection densitivity",
             icon="mdi:volume-vibrate",
             entity_category=EntityCategory.CONFIG,
             translation_key="decibel_sensitivity",
         ),
         SelectEntityDescription(
             key=DPCode.RECORD_MODE,
-            name="Record mode",
             icon="mdi:record-rec",
             entity_category=EntityCategory.CONFIG,
             translation_key="record_mode",
         ),
         SelectEntityDescription(
             key=DPCode.BASIC_NIGHTVISION,
-            name="Night vision",
             icon="mdi:theme-light-dark",
             entity_category=EntityCategory.CONFIG,
             translation_key="basic_nightvision",
         ),
         SelectEntityDescription(
             key=DPCode.BASIC_ANTI_FLICKER,
-            name="Anti-flicker",
             icon="mdi:image-outline",
             entity_category=EntityCategory.CONFIG,
             translation_key="basic_anti_flicker",
         ),
         SelectEntityDescription(
             key=DPCode.MOTION_SENSITIVITY,
-            name="Motion detection sensitivity",
             icon="mdi:motion-sensor",
             entity_category=EntityCategory.CONFIG,
             translation_key="motion_sensitivity",
@@ -285,13 +268,11 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "tdq": (
         SelectEntityDescription(
             key=DPCode.RELAY_STATUS,
-            name="Power on behavior",
             entity_category=EntityCategory.CONFIG,
             translation_key="relay_status",
         ),
         SelectEntityDescription(
             key=DPCode.LIGHT_MODE,
-            name="Indicator light mode",
             entity_category=EntityCategory.CONFIG,
             translation_key="light_mode",
         ),
@@ -301,33 +282,28 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "tgkg": (
         SelectEntityDescription(
             key=DPCode.RELAY_STATUS,
-            name="Power on behavior",
             entity_category=EntityCategory.CONFIG,
             translation_key="relay_status",
         ),
         SelectEntityDescription(
             key=DPCode.LIGHT_MODE,
-            name="Indicator light mode",
             entity_category=EntityCategory.CONFIG,
             translation_key="light_mode",
         ),
         SelectEntityDescription(
             key=DPCode.LED_TYPE_1,
-            name="Light source type",
             entity_category=EntityCategory.CONFIG,
             translation_key="led_type",
         ),
         SelectEntityDescription(
             key=DPCode.LED_TYPE_2,
-            name="Light 2 source type",
             entity_category=EntityCategory.CONFIG,
-            translation_key="led_type",
+            translation_key="led_type_2",
         ),
         SelectEntityDescription(
             key=DPCode.LED_TYPE_3,
-            name="Light 3 source type",
             entity_category=EntityCategory.CONFIG,
-            translation_key="led_type",
+            translation_key="led_type_3",
         ),
     ),
     # Dimmer
@@ -335,22 +311,19 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "tgq": (
         SelectEntityDescription(
             key=DPCode.LED_TYPE_1,
-            name="Light source type",
             entity_category=EntityCategory.CONFIG,
             translation_key="led_type",
         ),
         SelectEntityDescription(
             key=DPCode.LED_TYPE_2,
-            name="Light 2 source type",
             entity_category=EntityCategory.CONFIG,
-            translation_key="led_type",
+            translation_key="led_type_2",
         ),
     ),
     # Fingerbot
     "szjqr": (
         SelectEntityDescription(
             key=DPCode.MODE,
-            name="Mode",
             entity_category=EntityCategory.CONFIG,
             translation_key="fingerbot_mode",
         ),
@@ -360,21 +333,18 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "sd": (
         SelectEntityDescription(
             key=DPCode.CISTERN,
-            name="Water tank adjustment",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:water-opacity",
             translation_key="vacuum_cistern",
         ),
         SelectEntityDescription(
             key=DPCode.COLLECTION_MODE,
-            name="Dust collection mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:air-filter",
             translation_key="vacuum_collection",
         ),
         SelectEntityDescription(
             key=DPCode.MODE,
-            name="Mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:layers-outline",
             translation_key="vacuum_mode",
@@ -385,28 +355,24 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "fs": (
         SelectEntityDescription(
             key=DPCode.FAN_VERTICAL,
-            name="Vertical swing flap angle",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:format-vertical-align-center",
-            translation_key="fan_angle",
+            translation_key="vertical_fan_angle",
         ),
         SelectEntityDescription(
             key=DPCode.FAN_HORIZONTAL,
-            name="Horizontal swing flap angle",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:format-horizontal-align-center",
-            translation_key="fan_angle",
+            translation_key="horizontal_fan_angle",
         ),
         SelectEntityDescription(
             key=DPCode.COUNTDOWN,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
         ),
         SelectEntityDescription(
             key=DPCode.COUNTDOWN_SET,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
@@ -417,14 +383,12 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "cl": (
         SelectEntityDescription(
             key=DPCode.CONTROL_BACK_MODE,
-            name="Motor mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:swap-horizontal",
             translation_key="curtain_motor_mode",
         ),
         SelectEntityDescription(
             key=DPCode.MODE,
-            name="Mode",
             entity_category=EntityCategory.CONFIG,
             translation_key="curtain_mode",
         ),
@@ -434,35 +398,30 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "jsq": (
         SelectEntityDescription(
             key=DPCode.SPRAY_MODE,
-            name="Spray mode",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:spray",
             translation_key="humidifier_spray_mode",
         ),
         SelectEntityDescription(
             key=DPCode.LEVEL,
-            name="Spraying level",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:spray",
             translation_key="humidifier_level",
         ),
         SelectEntityDescription(
             key=DPCode.MOODLIGHTING,
-            name="Moodlighting",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:lightbulb-multiple",
             translation_key="humidifier_moodlighting",
         ),
         SelectEntityDescription(
             key=DPCode.COUNTDOWN,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
         ),
         SelectEntityDescription(
             key=DPCode.COUNTDOWN_SET,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
@@ -473,14 +432,12 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "kj": (
         SelectEntityDescription(
             key=DPCode.COUNTDOWN,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
         ),
         SelectEntityDescription(
             key=DPCode.COUNTDOWN_SET,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
@@ -491,14 +448,13 @@ SELECTS: dict[str, tuple[SelectEntityDescription, ...]] = {
     "cs": (
         SelectEntityDescription(
             key=DPCode.COUNTDOWN_SET,
-            name="Countdown",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:timer-cog-outline",
             translation_key="countdown",
         ),
         SelectEntityDescription(
             key=DPCode.DEHUMIDITY_SET_ENUM,
-            name="Target humidity",
+            translation_key="target_humidity",
             entity_category=EntityCategory.CONFIG,
             icon="mdi:water-percent",
         ),
@@ -537,19 +493,17 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya select."""
         entities: list[TuyaSelectEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := SELECTS.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaSelectEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaSelectEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -561,8 +515,8 @@ class TuyaSelectEntity(TuyaEntity, SelectEntity):
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: SelectEntityDescription,
     ) -> None:
         """Init Tuya sensor."""

--- a/custom_components/tuya/sensor.py
+++ b/custom_components/tuya/sensor.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
-from tuya_iot.device import TuyaDeviceStatusRange
+from tuya_sharing import CustomerDevice, Manager
+from tuya_sharing.device import DeviceStatusRange
 
 from homeassistant.components.sensor import (
     SensorDeviceClass,
@@ -38,7 +38,7 @@ from .const import (
 )
 
 
-@dataclass
+@dataclass(frozen=True)
 class TuyaSensorEntityDescription(SensorEntityDescription):
     """Describes Tuya sensor entity."""
 
@@ -49,7 +49,7 @@ class TuyaSensorEntityDescription(SensorEntityDescription):
 BATTERY_SENSORS: tuple[TuyaSensorEntityDescription, ...] = (
     TuyaSensorEntityDescription(
         key=DPCode.BATTERY_PERCENTAGE,
-        name="Battery",
+        translation_key="battery",
         native_unit_of_measurement=PERCENTAGE,
         device_class=SensorDeviceClass.BATTERY,
         state_class=SensorStateClass.MEASUREMENT,
@@ -57,31 +57,30 @@ BATTERY_SENSORS: tuple[TuyaSensorEntityDescription, ...] = (
     ),
     TuyaSensorEntityDescription(
         key=DPCode.BATTERY_STATE,
-        name="Battery state",
+        translation_key="battery_state",
         icon="mdi:battery",
         entity_category=EntityCategory.DIAGNOSTIC,
-        translation_key="battery_state",
     ),
     TuyaSensorEntityDescription(
         key=DPCode.BATTERY_VALUE,
-        name="Battery",
+        translation_key="battery",
         device_class=SensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     TuyaSensorEntityDescription(
         key=DPCode.VA_BATTERY,
-        name="Battery",
+        translation_key="battery",
         device_class=SensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
     ),
     TuyaSensorEntityDescription(
         key=DPCode.RESIDUAL_ELECTRICITY,
-        name="Battery",
         device_class=SensorDeviceClass.BATTERY,
         entity_category=EntityCategory.DIAGNOSTIC,
         state_class=SensorStateClass.MEASUREMENT,
+        translation_key="battery",
     ),
 )
 
@@ -95,73 +94,74 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "dgnbj": (
         TuyaSensorEntityDescription(
             key=DPCode.GAS_SENSOR_VALUE,
-            name="Gas",
+            translation_key="gas",
             icon="mdi:gas-cylinder",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CH4_SENSOR_VALUE,
+            translation_key="gas",
             name="Methane",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VOC_VALUE,
-            name="Volatile organic compound",
+            translation_key="voc",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM25_VALUE,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CO_VALUE,
-            name="Carbon monoxide",
+            translation_key="carbon_monoxide",
             icon="mdi:molecule-co",
             device_class=SensorDeviceClass.CO,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             icon="mdi:molecule-co2",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CH2O_VALUE,
-            name="Formaldehyde",
+            translation_key="formaldehyde",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.BRIGHT_STATE,
-            name="Luminosity",
+            translation_key="luminosity",
             icon="mdi:brightness-6",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.BRIGHT_VALUE,
-            name="Luminosity",
+            translation_key="illuminance",
             icon="mdi:brightness-6",
             device_class=SensorDeviceClass.ILLUMINANCE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.SMOKE_SENSOR_VALUE,
-            name="Smoke amount",
+            translation_key="smoke_amount",
             icon="mdi:smoke-detector",
             entity_category=EntityCategory.DIAGNOSTIC,
             state_class=SensorStateClass.MEASUREMENT,
@@ -173,19 +173,19 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "bh": (
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Current temperature",
+            translation_key="current_temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT_F,
-            name="Current temperature",
+            translation_key="current_temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.STATUS,
-            name="Status",
+            translation_key="status",
         ),
     ),
     # CO2 Detector
@@ -193,19 +193,19 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "co2bj": (
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -217,13 +217,13 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "wkcz": (
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -233,7 +233,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "cobj": (
         TuyaSensorEntityDescription(
             key=DPCode.CO_VALUE,
-            name="Carbon monoxide",
+            translation_key="carbon_monoxide",
             device_class=SensorDeviceClass.CO,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -244,7 +244,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "cwwsq": (
         TuyaSensorEntityDescription(
             key=DPCode.FEED_REPORT,
-            name="Last amount",
+            translation_key="last_amount",
             icon="mdi:counter",
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -254,36 +254,36 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "hjjcy": (
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CH2O_VALUE,
-            name="Formaldehyde",
+            translation_key="formaldehyde",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VOC_VALUE,
-            name="Volatile organic compound",
+            translation_key="voc",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM25_VALUE,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -293,37 +293,37 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "jqbj": (
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VOC_VALUE,
-            name="Volatile organic compound",
+            translation_key="voc",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM25_VALUE,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VA_HUMIDITY,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VA_TEMPERATURE,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CH2O_VALUE,
-            name="Formaldehyde",
+            translation_key="formaldehyde",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         *BATTERY_SENSORS,
@@ -333,7 +333,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "jwbj": (
         TuyaSensorEntityDescription(
             key=DPCode.CH4_SENSOR_VALUE,
-            name="Methane",
+            translation_key="methane",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         *BATTERY_SENSORS,
@@ -343,21 +343,21 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "kg": (
         TuyaSensorEntityDescription(
             key=DPCode.CUR_CURRENT,
-            name="Current",
+            translation_key="current",
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_POWER,
-            name="Power",
+            translation_key="power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_VOLTAGE,
-            name="Voltage",
+            translation_key="voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
@@ -368,21 +368,21 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "tdq": (
         TuyaSensorEntityDescription(
             key=DPCode.CUR_CURRENT,
-            name="Current",
+            translation_key="current",
             device_class=SensorDeviceClass.CURRENT,
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_POWER,
-            name="Power",
+            translation_key="power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CUR_VOLTAGE,
-            name="Voltage",
+            translation_key="voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             entity_registry_enabled_default=False,
@@ -393,30 +393,30 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "ldcg": (
         TuyaSensorEntityDescription(
             key=DPCode.BRIGHT_STATE,
-            name="Luminosity",
+            translation_key="luminosity",
             icon="mdi:brightness-6",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.BRIGHT_VALUE,
-            name="Luminosity",
+            translation_key="illuminance",
             device_class=SensorDeviceClass.ILLUMINANCE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -433,147 +433,143 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "ms": (
         TuyaSensorEntityDescription(
             key=DPCode.ALARM_LOCK,
-            name="Last alert",
             icon="mdi:information-outline",
             translation_key="lock_alarm",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CLOSED_OPENED,
-            name="Door",
             icon="mdi:lock",
             translation_key="lock_status",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.ANTILOCK_STATUS,
-            name="Double locking status",
             icon="mdi:lock-check",
             translation_key="lock_antilock",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.INSURANCE_STATUS,
-            name="Latching status",
             icon="mdi:lock-check",
             translation_key="lock_insurance",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_FINGERPRINT,
-            name="Last ID fingerprint",
             icon="mdi:fingerprint",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_fingerprint",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_PASSWORD,
-            name="Last ID password",
             icon="mdi:form-textbox-password",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_password",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_TEMPORARY,
-            name="Last ID temporary password",
             icon="mdi:form-textbox-password",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_temporary_password",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_DYNAMIC,
-            name="Last ID dynamic password",
             icon="mdi:form-textbox-password",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_dynamic_password",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_CARD,
-            name="Last ID card",
             icon="mdi:card-bulleted-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_card",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_IDENITY_CARD,
-            name="Last ID identity card",
             icon="mdi:card-account-details-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_identity_card",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_FACE,
-            name="Last ID face recognition",
             icon="mdi:face-recognition",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_face_recognition",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_KEY,
-            name="Last ID mechanical key",
             icon="mdi:key-chain-variant",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_mechanical_key",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_EYE,
-            name="Last ID iris",
             icon="mdi:eye-check-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_iris",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_HAND,
-            name="Last ID palm print",
             icon="mdi:hand-back-left-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_palm_print",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_FINGER_VEIN,
-            name="Last ID finger vein",
             icon="mdi:hand-pointing-up",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_finger_vein",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_BLE,
-            name="Last ID bluetooth",
             icon="mdi:bluetooth",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_bluetooth",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_REMOTE,
-            name="Last ID remote",
             icon="mdi:wan",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_remote",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_PHONE_REMOTE,
-            name="Last ID mobile phone",
             icon="mdi:cellphone-key",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_mobile_phone",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_VOICE_REMOTE,
-            name="Last ID voice (remote)",
             icon="mdi:cellphone-key",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_voice",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_APP,
-            name="Last ID app (remote)",
             icon="mdi:open-in-app",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_app",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_ACCESS_CONTROL,
-            name="Last ID access control system",
             icon="mdi:account-circle-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_access_control_system",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_EMERGENCY,
-            name="Last ID emergency password",
             icon="mdi:car-brake-alert",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_emergency_password",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_ADMIN,
-            name="Last ID administrator",
             icon="mdi:account-check-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_administrator",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.UNLOCK_SUBADMIN,
-            name="Last ID housekeeper",
             icon="mdi:account-check-outline",
             entity_category=EntityCategory.DIAGNOSTIC,
+            translation_key="lock_last_housekeeper",
         ),
         *BATTERY_SENSORS,
     ),
@@ -582,18 +578,17 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "mzj": (
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Current temperature",
+            translation_key="current_temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.STATUS,
-            name="Status",
-            translation_key="status",
+            translation_key="sous_vide_status",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.REMAIN_TIME,
-            name="Remaining time",
+            translation_key="remaining_time",
             native_unit_of_measurement=UnitOfTime.MINUTES,
             icon="mdi:timer",
         ),
@@ -606,48 +601,48 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "pm2.5": (
         TuyaSensorEntityDescription(
             key=DPCode.PM25_VALUE,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CH2O_VALUE,
-            name="Formaldehyde",
+            translation_key="formaldehyde",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VOC_VALUE,
-            name="Volatile organic compound",
+            translation_key="voc",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM1,
-            name="Particulate matter 1.0 µm",
+            translation_key="pm1",
             device_class=SensorDeviceClass.PM1,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM10,
-            name="Particulate matter 10.0 µm",
+            translation_key="pm10",
             device_class=SensorDeviceClass.PM10,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -658,7 +653,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "qn": (
         TuyaSensorEntityDescription(
             key=DPCode.WORK_POWER,
-            name="Power",
+            translation_key="power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -668,8 +663,21 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "rqbj": (
         TuyaSensorEntityDescription(
             key=DPCode.GAS_SENSOR_VALUE,
+            name=None,
             icon="mdi:gas-cylinder",
             state_class=SensorStateClass.MEASUREMENT,
+        ),
+        *BATTERY_SENSORS,
+    ),
+    # Smart Water Timer
+    "sfkzq": (
+        # Total seconds of irrigation. Read-write value; the device appears to ignore the write action (maybe firmware bug)
+        TuyaSensorEntityDescription(
+            key=DPCode.TIME_USE,
+            translation_key="total_watering_time",
+            icon="mdi:history",
+            state_class=SensorStateClass.TOTAL_INCREASING,
+            entity_category=EntityCategory.DIAGNOSTIC,
         ),
         *BATTERY_SENSORS,
     ),
@@ -684,19 +692,19 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "sp": (
         TuyaSensorEntityDescription(
             key=DPCode.SENSOR_TEMPERATURE,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.SENSOR_HUMIDITY,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.WIRELESS_ELECTRICITY,
-            name="Battery",
+            translation_key="battery",
             device_class=SensorDeviceClass.BATTERY,
             entity_category=EntityCategory.DIAGNOSTIC,
             state_class=SensorStateClass.MEASUREMENT,
@@ -712,36 +720,36 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "voc": (
         TuyaSensorEntityDescription(
             key=DPCode.CO2_VALUE,
-            name="Carbon dioxide",
+            translation_key="carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM25_VALUE,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CH2O_VALUE,
-            name="Formaldehyde",
+            translation_key="formaldehyde",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VOC_VALUE,
-            name="Volatile organic compound",
+            translation_key="voc",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -755,31 +763,31 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "wsdcg": (
         TuyaSensorEntityDescription(
             key=DPCode.VA_TEMPERATURE,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VA_HUMIDITY,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_VALUE,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.BRIGHT_VALUE,
-            name="Luminosity",
+            translation_key="illuminance",
             device_class=SensorDeviceClass.ILLUMINANCE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -790,6 +798,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "ylcg": (
         TuyaSensorEntityDescription(
             key=DPCode.PRESSURE_VALUE,
+            name=None,
             device_class=SensorDeviceClass.PRESSURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -800,7 +809,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "ywbj": (
         TuyaSensorEntityDescription(
             key=DPCode.SMOKE_SENSOR_VALUE,
-            name="Smoke amount",
+            translation_key="smoke_amount",
             icon="mdi:smoke-detector",
             entity_category=EntityCategory.DIAGNOSTIC,
             state_class=SensorStateClass.MEASUREMENT,
@@ -815,13 +824,13 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "zndb": (
         TuyaSensorEntityDescription(
             key=DPCode.FORWARD_ENERGY_TOTAL,
-            name="Total energy",
+            translation_key="total_energy",
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_A,
-            name="Phase A current",
+            translation_key="phase_a_current",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -829,7 +838,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_A,
-            name="Phase A power",
+            translation_key="phase_a_power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
@@ -837,7 +846,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_A,
-            name="Phase A voltage",
+            translation_key="phase_a_voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -845,7 +854,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_B,
-            name="Phase B current",
+            translation_key="phase_b_current",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -853,7 +862,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_B,
-            name="Phase B power",
+            translation_key="phase_b_power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
@@ -861,7 +870,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_B,
-            name="Phase B voltage",
+            translation_key="phase_b_voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -869,7 +878,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_C,
-            name="Phase C current",
+            translation_key="phase_c_current",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -877,7 +886,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_C,
-            name="Phase C power",
+            translation_key="phase_c_power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
@@ -885,7 +894,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_C,
-            name="Phase C voltage",
+            translation_key="phase_c_voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -897,13 +906,13 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "dlq": (
         TuyaSensorEntityDescription(
             key=DPCode.TOTAL_FORWARD_ENERGY,
-            name="Total energy",
+            translation_key="total_energy",
             device_class=SensorDeviceClass.ENERGY,
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_A,
-            name="Phase A current",
+            translation_key="phase_a_current",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -911,7 +920,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_A,
-            name="Phase A power",
+            translation_key="phase_a_power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
@@ -919,7 +928,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_A,
-            name="Phase A voltage",
+            translation_key="phase_a_voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -927,7 +936,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_B,
-            name="Phase B current",
+            translation_key="phase_b_current",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -935,7 +944,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_B,
-            name="Phase B power",
+            translation_key="phase_b_power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
@@ -943,7 +952,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_B,
-            name="Phase B voltage",
+            translation_key="phase_b_voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
@@ -951,7 +960,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_C,
-            name="Phase C current",
+            translation_key="phase_c_current",
             device_class=SensorDeviceClass.CURRENT,
             native_unit_of_measurement=UnitOfElectricCurrent.AMPERE,
             state_class=SensorStateClass.MEASUREMENT,
@@ -959,7 +968,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_C,
-            name="Phase C power",
+            translation_key="phase_c_power",
             device_class=SensorDeviceClass.POWER,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfPower.KILO_WATT,
@@ -967,11 +976,32 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PHASE_C,
-            name="Phase C voltage",
+            translation_key="phase_c_voltage",
             device_class=SensorDeviceClass.VOLTAGE,
             state_class=SensorStateClass.MEASUREMENT,
             native_unit_of_measurement=UnitOfElectricPotential.VOLT,
             subkey="voltage",
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.CUR_CURRENT,
+            translation_key="current",
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.CUR_POWER,
+            translation_key="power",
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.CUR_VOLTAGE,
+            translation_key="voltage",
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_registry_enabled_default=False,
         ),
     ),
     # Robot Vacuum
@@ -979,55 +1009,55 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "sd": (
         TuyaSensorEntityDescription(
             key=DPCode.CLEAN_AREA,
-            name="Cleaning area",
+            translation_key="cleaning_area",
             icon="mdi:texture-box",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.CLEAN_TIME,
-            name="Cleaning time",
+            translation_key="cleaning_time",
             icon="mdi:progress-clock",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TOTAL_CLEAN_AREA,
-            name="Total cleaning area",
+            translation_key="total_cleaning_area",
             icon="mdi:texture-box",
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TOTAL_CLEAN_TIME,
-            name="Total cleaning time",
+            translation_key="total_cleaning_time",
             icon="mdi:history",
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TOTAL_CLEAN_COUNT,
-            name="Total cleaning times",
+            translation_key="total_cleaning_times",
             icon="mdi:counter",
             state_class=SensorStateClass.TOTAL_INCREASING,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.DUSTER_CLOTH,
-            name="Duster cloth life",
+            translation_key="duster_cloth_life",
             icon="mdi:ticket-percent-outline",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.EDGE_BRUSH,
-            name="Side brush life",
+            translation_key="side_brush_life",
             icon="mdi:ticket-percent-outline",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.FILTER_LIFE,
-            name="Filter life",
+            translation_key="filter_life",
             icon="mdi:ticket-percent-outline",
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.ROLL_BRUSH,
-            name="Rolling brush life",
+            translation_key="rolling_brush_life",
             icon="mdi:ticket-percent-outline",
             state_class=SensorStateClass.MEASUREMENT,
         ),
@@ -1037,7 +1067,7 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "cl": (
         TuyaSensorEntityDescription(
             key=DPCode.TIME_TOTAL,
-            name="Last operation duration",
+            translation_key="last_operation_duration",
             entity_category=EntityCategory.DIAGNOSTIC,
             icon="mdi:progress-clock",
         ),
@@ -1047,25 +1077,25 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "jsq": (
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_CURRENT,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT_F,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.LEVEL_CURRENT,
-            name="Water level",
+            translation_key="water_level",
             entity_category=EntityCategory.DIAGNOSTIC,
             icon="mdi:waves-arrow-up",
         ),
@@ -1075,60 +1105,59 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "kj": (
         TuyaSensorEntityDescription(
             key=DPCode.FILTER,
-            name="Filter utilization",
+            translation_key="filter_utilization",
             entity_category=EntityCategory.DIAGNOSTIC,
             icon="mdi:ticket-percent-outline",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.PM25,
-            name="Particulate matter 2.5 µm",
+            translation_key="pm25",
             device_class=SensorDeviceClass.PM25,
             state_class=SensorStateClass.MEASUREMENT,
             icon="mdi:molecule",
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TEMP,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TVOC,
-            name="Total volatile organic compound",
+            translation_key="total_volatile_organic_compound",
             device_class=SensorDeviceClass.VOLATILE_ORGANIC_COMPOUNDS,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.ECO2,
-            name="Concentration of carbon dioxide",
+            translation_key="concentration_carbon_dioxide",
             device_class=SensorDeviceClass.CO2,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TOTAL_TIME,
-            name="Total operating time",
+            translation_key="total_operating_time",
             icon="mdi:history",
             state_class=SensorStateClass.TOTAL_INCREASING,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.TOTAL_PM,
-            name="Total absorption of particles",
+            translation_key="total_absorption_particles",
             icon="mdi:texture-box",
             state_class=SensorStateClass.TOTAL_INCREASING,
             entity_category=EntityCategory.DIAGNOSTIC,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.AIR_QUALITY,
-            name="Air quality",
-            icon="mdi:air-filter",
             translation_key="air_quality",
+            icon="mdi:air-filter",
         ),
     ),
     # Fan
@@ -1136,24 +1165,49 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "fs": (
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_CURRENT,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
     ),
     # eMylo Smart WiFi IR Remote
+    # Air Conditioner Mate (Smart IR Socket)
     "wnykq": (
         TuyaSensorEntityDescription(
             key=DPCode.VA_TEMPERATURE,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.VA_HUMIDITY,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.CUR_CURRENT,
+            translation_key="current",
+            device_class=SensorDeviceClass.CURRENT,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.CUR_POWER,
+            translation_key="power",
+            device_class=SensorDeviceClass.POWER,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.CUR_VOLTAGE,
+            translation_key="voltage",
+            device_class=SensorDeviceClass.VOLTAGE,
+            state_class=SensorStateClass.MEASUREMENT,
+            entity_category=EntityCategory.DIAGNOSTIC,
+            entity_registry_enabled_default=False,
         ),
     ),
     # Dehumidifier
@@ -1161,16 +1215,32 @@ SENSORS: dict[str, tuple[TuyaSensorEntityDescription, ...]] = {
     "cs": (
         TuyaSensorEntityDescription(
             key=DPCode.TEMP_INDOOR,
-            name="Temperature",
+            translation_key="temperature",
             device_class=SensorDeviceClass.TEMPERATURE,
             state_class=SensorStateClass.MEASUREMENT,
         ),
         TuyaSensorEntityDescription(
             key=DPCode.HUMIDITY_INDOOR,
-            name="Humidity",
+            translation_key="humidity",
             device_class=SensorDeviceClass.HUMIDITY,
             state_class=SensorStateClass.MEASUREMENT,
         ),
+    ),
+    # Soil sensor (Plant monitor)
+    "zwjcy": (
+        TuyaSensorEntityDescription(
+            key=DPCode.TEMP_CURRENT,
+            translation_key="temperature",
+            device_class=SensorDeviceClass.TEMPERATURE,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        TuyaSensorEntityDescription(
+            key=DPCode.HUMIDITY,
+            translation_key="humidity",
+            device_class=SensorDeviceClass.HUMIDITY,
+            state_class=SensorStateClass.MEASUREMENT,
+        ),
+        *BATTERY_SENSORS,
     ),
 }
 
@@ -1206,19 +1276,17 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya sensor."""
         entities: list[TuyaSensorEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := SENSORS.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaSensorEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaSensorEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -1230,15 +1298,15 @@ class TuyaSensorEntity(TuyaEntity, SensorEntity):
 
     entity_description: TuyaSensorEntityDescription
 
-    _status_range: TuyaDeviceStatusRange | None = None
+    _status_range: DeviceStatusRange | None = None
     _type: DPType | None = None
     _type_data: IntegerTypeData | EnumTypeData | None = None
     _uom: UnitOfMeasurement | None = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: TuyaSensorEntityDescription,
     ) -> None:
         """Init Tuya sensor."""

--- a/custom_components/tuya/siren.py
+++ b/custom_components/tuya/siren.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.siren import (
     SirenEntity,
@@ -27,7 +27,6 @@ SIRENS: dict[str, tuple[SirenEntityDescription, ...]] = {
     "dgnbj": (
         SirenEntityDescription(
             key=DPCode.ALARM_SWITCH,
-            name="Siren",
         ),
     ),
     # Siren Alarm
@@ -35,7 +34,6 @@ SIRENS: dict[str, tuple[SirenEntityDescription, ...]] = {
     "sgbj": (
         SirenEntityDescription(
             key=DPCode.ALARM_SWITCH,
-            name="Siren",
         ),
     ),
     # Smart Camera
@@ -43,7 +41,6 @@ SIRENS: dict[str, tuple[SirenEntityDescription, ...]] = {
     "sp": (
         SirenEntityDescription(
             key=DPCode.SIREN_SWITCH,
-            name="Siren",
         ),
     ),
 }
@@ -60,19 +57,17 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya siren."""
         entities: list[TuyaSirenEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := SIRENS.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaSirenEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaSirenEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -83,11 +78,12 @@ class TuyaSirenEntity(TuyaEntity, SirenEntity):
     """Tuya Siren Entity."""
 
     _attr_supported_features = SirenEntityFeature.TURN_ON | SirenEntityFeature.TURN_OFF
+    _attr_name = None
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: SirenEntityDescription,
     ) -> None:
         """Init Tuya Siren."""

--- a/custom_components/tuya/strings.json
+++ b/custom_components/tuya/strings.json
@@ -1,32 +1,266 @@
 {
   "config": {
     "step": {
-      "user": {
-        "description": "Enter your Tuya credentials",
+      "reauth_user_code": {
+        "description": "The Tuya integration now uses an improved login method. To reauthenticate with your Smart Life or Tuya Smart account, you need to enter your user code.\n\nYou can find this code in the Smart Life app or Tuya Smart app in **Settings** > **Account and Security** screen, and enter the code shown on the **User Code** field. The user code is case sensitive, please be sure to enter it exactly as shown in the app.",
         "data": {
-          "country_code": "Country",
-          "access_id": "Tuya IoT Access ID",
-          "access_secret": "Tuya IoT Access Secret",
-          "username": "Account",
-          "password": "[%key:common::config_flow::data::password%]"
+          "user_code": "User code"
         }
+      },
+      "user": {
+        "description": "Enter your Smart Life or Tuya Smart user code.\n\nYou can find this code in the Smart Life app or Tuya Smart app in **Settings** > **Account and Security** screen, and enter the code shown on the **User Code** field. The user code is case sensitive, please be sure to enter it exactly as shown in the app.",
+        "data": {
+          "user_code": "User code"
+        }
+      },
+      "scan": {
+        "description": "Use Smart Life app or Tuya Smart app to scan the following QR-code to complete the login:\n\n {qrcode} \n\nContinue to the next step once you have completed this step in the app."
       }
     },
     "error": {
       "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-      "login_error": "Login error ({code}): {msg}"
+      "login_error": "Login error ({code}): {msg}",
+      "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]"
     }
   },
   "entity": {
+    "binary_sensor": {
+      "methane": {
+        "name": "Methane"
+      },
+      "voc": {
+        "name": "VOCs"
+      },
+      "pm25": {
+        "name": "PM2.5"
+      },
+      "carbon_monoxide": {
+        "name": "Carbon monoxide"
+      },
+      "carbon_dioxide": {
+        "name": "Carbon dioxide"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "formaldehyde": {
+        "name": "Formaldehyde"
+      },
+      "pressure": {
+        "name": "Pressure"
+      },
+      "feeding": {
+        "name": "Feeding"
+      },
+      "drop": {
+        "name": "Drop"
+      },
+      "tilt": {
+        "name": "Tilt"
+      },
+      "lock_doorbell": {
+        "name": "Doorbell"
+      },
+      "lock_duress_alert": {
+        "name": "Duress alert"
+      },
+      "lock_open_close": {
+        "name": "Locking and unlocking event"
+      },
+      "lock_open_inside": {
+        "name": "Unlock inside of door"
+      },
+      "lock_reverse": {
+        "name": "Double locking status"
+      },
+      "lock_status": {
+        "name": "Status"
+      },
+      "lock_anti_outside": {
+        "name": "Double locking by lifting up"
+      }
+    },
+    "button": {
+      "reset_duster_cloth": {
+        "name": "Reset duster cloth"
+      },
+      "reset_edge_brush": {
+        "name": "Reset edge brush"
+      },
+      "reset_filter": {
+        "name": "Reset filter"
+      },
+      "reset_map": {
+        "name": "Reset map"
+      },
+      "reset_roll_brush": {
+        "name": "Reset roll brush"
+      },
+      "snooze": {
+        "name": "Snooze"
+      }
+    },
+    "cover": {
+      "blind": {
+        "name": "[%key:component::cover::entity_component::blind::name%]"
+      },
+      "curtain": {
+        "name": "[%key:component::cover::entity_component::curtain::name%]"
+      },
+      "curtain_2": {
+        "name": "Curtain 2"
+      },
+      "curtain_3": {
+        "name": "Curtain 3"
+      },
+      "door": {
+        "name": "[%key:component::cover::entity_component::door::name%]"
+      },
+      "door_2": {
+        "name": "Door 2"
+      },
+      "door_3": {
+        "name": "Door 3"
+      }
+    },
+    "light": {
+      "backlight": {
+        "name": "Backlight"
+      },
+      "light": {
+        "name": "[%key:component::light::title%]"
+      },
+      "light_2": {
+        "name": "Light 2"
+      },
+      "light_3": {
+        "name": "Light 3"
+      },
+      "night_light": {
+        "name": "Night light"
+      }
+    },
+    "number": {
+      "temperature": {
+        "name": "[%key:component::sensor::entity_component::temperature::name%]"
+      },
+      "time": {
+        "name": "Time"
+      },
+      "temperature_after_boiling": {
+        "name": "Temperature after boiling"
+      },
+      "heat_preservation_time": {
+        "name": "Heat preservation time"
+      },
+      "feed": {
+        "name": "Feed"
+      },
+      "voice_times": {
+        "name": "Voice times"
+      },
+      "sensitivity": {
+        "name": "Sensitivity"
+      },
+      "near_detection": {
+        "name": "Near detection"
+      },
+      "far_detection": {
+        "name": "Far detection"
+      },
+      "water_level": {
+        "name": "Water level"
+      },
+      "powder": {
+        "name": "Powder"
+      },
+      "cook_temperature": {
+        "name": "Cook temperature"
+      },
+      "cook_time": {
+        "name": "Cook time"
+      },
+      "cloud_recipe": {
+        "name": "Cloud recipe"
+      },
+      "volume": {
+        "name": "Volume"
+      },
+      "minimum_brightness": {
+        "name": "Minimum brightness"
+      },
+      "maximum_brightness": {
+        "name": "Maximum brightness"
+      },
+      "minimum_brightness_2": {
+        "name": "Minimum brightness 2"
+      },
+      "maximum_brightness_2": {
+        "name": "Maximum brightness 2"
+      },
+      "minimum_brightness_3": {
+        "name": "Minimum brightness 3"
+      },
+      "maximum_brightness_3": {
+        "name": "Maximum brightness 3"
+      },
+      "move_down": {
+        "name": "Move down"
+      },
+      "move_up": {
+        "name": "Move up"
+      },
+      "down_delay": {
+        "name": "Down delay"
+      },
+      "lock_time_auto": {
+        "name": "Auto lock time"
+      },
+      "lock_stay_hold_time": {
+        "name": "Loitering hold time"
+      },
+      "lock_open_rate": {
+        "name": "Opening percentage"
+      },
+      "lock_alarm_time": {
+        "name": "Alert duration"
+      }
+    },
     "select": {
+      "volume": {
+        "name": "[%key:component::tuya::entity::number::volume::name%]"
+      },
+      "cups": {
+        "name": "Cups"
+      },
+      "concentration": {
+        "name": "Concentration"
+      },
+      "material": {
+        "name": "Material"
+      },
+      "mode": {
+        "name": "Mode"
+      },
+      "temperature_level": {
+        "name": "Temperature level"
+      },
+      "brightness": {
+        "name": "Brightness"
+      },
+      "target_humidity": {
+        "name": "Target humidity"
+      },
       "basic_anti_flicker": {
+        "name": "Anti-flicker",
         "state": {
-          "0": "Disabled",
+          "0": "[%key:common::state::disabled%]",
           "1": "50 Hz",
           "2": "60 Hz"
         }
       },
       "basic_nightvision": {
+        "name": "Night vision",
         "state": {
           "0": "Automatic",
           "1": "[%key:common::state::off%]",
@@ -34,25 +268,45 @@
         }
       },
       "decibel_sensitivity": {
+        "name": "Sound detection sensitivity",
         "state": {
           "0": "Low sensitivity",
           "1": "High sensitivity"
         }
       },
       "ipc_work_mode": {
+        "name": "IPC mode",
         "state": {
           "0": "Low power mode",
           "1": "Continuous working mode"
         }
       },
       "led_type": {
+        "name": "Light source type",
         "state": {
           "halogen": "Halogen",
           "incandescent": "Incandescent",
           "led": "LED"
         }
       },
+      "led_type_2": {
+        "name": "Light 2 source type",
+        "state": {
+          "halogen": "[%key:component::tuya::entity::select::led_type::state::halogen%]",
+          "incandescent": "[%key:component::tuya::entity::select::led_type::state::incandescent%]",
+          "led": "[%key:component::tuya::entity::select::led_type::state::led%]"
+        }
+      },
+      "led_type_3": {
+        "name": "Light 3 source type",
+        "state": {
+          "halogen": "[%key:component::tuya::entity::select::led_type::state::halogen%]",
+          "incandescent": "[%key:component::tuya::entity::select::led_type::state::incandescent%]",
+          "led": "[%key:component::tuya::entity::select::led_type::state::led%]"
+        }
+      },
       "light_mode": {
+        "name": "Indicator light mode",
         "state": {
           "none": "[%key:common::state::off%]",
           "pos": "Indicate switch location",
@@ -60,6 +314,7 @@
         }
       },
       "motion_sensitivity": {
+        "name": "Motion detection sensitivity",
         "state": {
           "0": "Low sensitivity",
           "1": "Medium sensitivity",
@@ -67,15 +322,17 @@
         }
       },
       "record_mode": {
+        "name": "Record mode",
         "state": {
           "1": "Record events only",
           "2": "Continuous recording"
         }
       },
       "relay_status": {
+        "name": "Power on behavior",
         "state": {
           "last": "Remember last state",
-          "memory": "Remember last state",
+          "memory": "[%key:component::tuya::entity::select::relay_status::state::last%]",
           "off": "[%key:common::state::off%]",
           "on": "[%key:common::state::on%]",
           "power_off": "[%key:common::state::off%]",
@@ -83,20 +340,23 @@
         }
       },
       "fingerbot_mode": {
+        "name": "Mode",
         "state": {
           "click": "Push",
           "switch": "Switch"
         }
       },
       "vacuum_cistern": {
+        "name": "Water tank adjustment",
         "state": {
           "low": "Low",
           "middle": "Middle",
           "high": "High",
-          "closed": "Closed"
+          "closed": "[%key:common::state::closed%]"
         }
       },
       "vacuum_collection": {
+        "name": "Dust collection mode",
         "state": {
           "small": "Small",
           "middle": "Middle",
@@ -104,29 +364,39 @@
         }
       },
       "vacuum_mode": {
+        "name": "Mode",
         "state": {
-          "standby": "Standby",
+          "standby": "[%key:common::state::standby%]",
           "random": "Random",
           "smart": "Smart",
-          "wall_follow": "Follow Wall",
+          "wall_follow": "Follow wall",
           "mop": "Mop",
           "spiral": "Spiral",
-          "left_spiral": "Spiral Left",
-          "right_spiral": "Spiral Right",
+          "left_spiral": "Spiral left",
+          "right_spiral": "Spiral right",
           "bow": "Bow",
-          "left_bow": "Bow Left",
-          "right_bow": "Bow Right",
-          "partial_bow": "Bow Partially",
+          "left_bow": "Bow left",
+          "right_bow": "Bow right",
+          "partial_bow": "Bow partially",
           "chargego": "Return to dock",
           "single": "Single",
           "zone": "Zone",
           "pose": "Pose",
           "point": "Point",
           "part": "Part",
-          "pick_zone": "Pick Zone"
+          "pick_zone": "Pick zone"
         }
       },
-      "fan_angle": {
+      "vertical_fan_angle": {
+        "name": "Vertical swing flap angle",
+        "state": {
+          "30": "30°",
+          "60": "60°",
+          "90": "90°"
+        }
+      },
+      "horizontal_fan_angle": {
+        "name": "Horizontal swing flap angle",
         "state": {
           "30": "30°",
           "60": "60°",
@@ -134,18 +404,21 @@
         }
       },
       "curtain_mode": {
+        "name": "Mode",
         "state": {
           "morning": "Morning",
           "night": "Night"
         }
       },
       "curtain_motor_mode": {
+        "name": "Motor mode",
         "state": {
           "forward": "Forward",
           "back": "Back"
         }
       },
       "countdown": {
+        "name": "Countdown",
         "state": {
           "cancel": "Cancel",
           "1h": "1 hour",
@@ -157,6 +430,7 @@
         }
       },
       "humidifier_spray_mode": {
+        "name": "Spray mode",
         "state": {
           "auto": "Auto",
           "health": "Health",
@@ -166,6 +440,7 @@
         }
       },
       "humidifier_level": {
+        "name": "Spraying level",
         "state": {
           "level_1": "Level 1",
           "level_2": "Level 2",
@@ -180,6 +455,7 @@
         }
       },
       "humidifier_moodlighting": {
+        "name": "Moodlighting",
         "state": {
           "1": "Mood 1",
           "2": "Mood 2",
@@ -189,6 +465,7 @@
         }
       },
       "language": {
+        "name": "Language",
         "state": {
           "chinese_simplified": "Chinese Simplified",
           "english": "English",
@@ -205,6 +482,7 @@
         }
       },
       "lock_alarm_volume": {
+        "name": "Alert volume",
         "state": {
           "mute": "Mute",
           "low": "Low",
@@ -213,13 +491,33 @@
         }
       },
       "lock_basic_nightvision": {
+        "name": "Infrared (IR) night vision",
         "state": {
           "0": "Level 1",
           "1": "Level 2",
           "2": "Level 3"
         }
       },
+      "lock_voice_volume": {
+        "name": "Local voice volume",
+        "state": {
+          "mute": "Mute",
+          "low": "Low",
+          "normal": "Normal",
+          "high": "High"
+        }
+      },
       "lock_doorbell_volume": {
+        "name": "Doorbell volume",
+        "state": {
+          "mute": "Mute",
+          "low": "Low",
+          "normal": "Normal",
+          "high": "High"
+        }
+      },
+      "lock_keypress_volume": {
+        "name": "Volume on keypress",
         "state": {
           "mute": "Mute",
           "low": "Low",
@@ -228,6 +526,7 @@
         }
       },
       "lock_door_unclosed_trigger": {
+        "name": "Trigger time of unclosed",
         "state": {
           "5s": "5 seconds",
           "10s": "10 seconds",
@@ -237,6 +536,7 @@
         }
       },
       "lock_doorbell_song": {
+        "name": "Doorbell ringtone",
         "state": {
           "ding_0": "Song 1",
           "ding_1": "Song 2",
@@ -251,12 +551,14 @@
         }
       },
       "lock_motor_direction": {
+        "name": "Rotation direction of motor",
         "state": {
           "clockwise": "Clockwise",
           "anti_clockwise": "Anti Clockwise"
         }
       },
       "lock_low_power_threshold": {
+        "name": "Low battery alert",
         "state": {
           "5_percent": "5%",
           "10_percent": "10%",
@@ -265,6 +567,7 @@
         }
       },
       "lock_motor_torque": {
+        "name": "Torque force of motor",
         "state": {
           "torque_low": "Low",
           "torque_middle": "Middle",
@@ -272,6 +575,7 @@
         }
       },
       "lock_open_speed_state": {
+        "name": "Unlocking speed",
         "state": {
           "low": "Low",
           "middle": "Middle",
@@ -279,6 +583,7 @@
         }
       },
       "lock_photo_mode": {
+        "name": "Photo mode",
         "state": {
           "close": "Close",
           "power_save": "Power Save",
@@ -287,6 +592,7 @@
         }
       },
       "lock_ringtone": {
+        "name": "Local ringtone",
         "state": {
           "sound_1": "Sound 1",
           "sound_2": "Sound 2",
@@ -297,6 +603,7 @@
         }
       },
       "lock_sound_mode": {
+        "name": "Sound mode",
         "state": {
           "ringtone_0": "Ringtone 1",
           "ringtone_1": "Ringtone 2",
@@ -307,6 +614,7 @@
         }
       },
       "lock_stay_alarm_mode": {
+        "name": "Loitering alert mode",
         "state": {
           "close": "Close",
           "normal": "Normal",
@@ -315,12 +623,14 @@
         }
       },
       "lock_stay_capture_mode": {
+        "name": "Loitering photo capture mode",
         "state": {
           "mode_1": "Mode 1",
           "mode_2": "Mode 2"
         }
       },
       "lock_stay_trigger_distance": {
+        "name": "Loitering sensing range",
         "state": {
           "away_from": "Away From",
           "close_to": "Close To",
@@ -328,6 +638,7 @@
         }
       },
       "lock_unlock_switch": {
+        "name": "Unlock mode",
         "state": {
           "combination": "Combination",
           "single_unlock": "Single Unlock",
@@ -338,31 +649,63 @@
           "password_face": "Password and Face",
           "card_face": "Card and Face"
         }
+      },
+      "weather_delay": {
+        "name": "Weather delay",
+        "state": {
+          "cancel": "Cancel",
+          "24h": "24h",
+          "48h": "48h",
+          "72h": "72h",
+          "96h": "96h",
+          "120h": "120h",
+          "144h": "144h",
+          "168h": "168h"
+        }
       }
     },
     "sensor": {
-      "status": {
-        "state": {
-          "boiling_temp": "Boiling temperature",
-          "cooling": "Cooling",
-          "heating_temp": "Heating temperature",
-          "heating": "Heating",
-          "reserve_1": "Reserve 1",
-          "reserve_2": "Reserve 2",
-          "reserve_3": "Reserve 3",
-          "standby": "Standby",
-          "warm": "Heat preservation"
-        }
+      "battery": {
+        "name": "[%key:component::sensor::entity_component::battery::name%]"
       },
-      "air_quality": {
-        "state": {
-          "great": "Great",
-          "mild": "Mild",
-          "good": "Good",
-          "severe": "Severe"
-        }
+      "voc": {
+        "name": "[%key:component::sensor::entity_component::volatile_organic_compounds::name%]"
+      },
+      "carbon_monoxide": {
+        "name": "[%key:component::sensor::entity_component::carbon_monoxide::name%]"
+      },
+      "carbon_dioxide": {
+        "name": "[%key:component::sensor::entity_component::carbon_dioxide::name%]"
+      },
+      "illuminance": {
+        "name": "[%key:component::sensor::entity_component::illuminance::name%]"
+      },
+      "temperature": {
+        "name": "[%key:component::sensor::entity_component::temperature::name%]"
+      },
+      "humidity": {
+        "name": "[%key:component::sensor::entity_component::humidity::name%]"
+      },
+      "pm25": {
+        "name": "[%key:component::sensor::entity_component::pm25::name%]"
+      },
+      "pm1": {
+        "name": "[%key:component::sensor::entity_component::pm1::name%]"
+      },
+      "pm10": {
+        "name": "[%key:component::sensor::entity_component::pm10::name%]"
+      },
+      "current": {
+        "name": "[%key:component::sensor::entity_component::current::name%]"
+      },
+      "power": {
+        "name": "[%key:component::sensor::entity_component::power::name%]"
+      },
+      "voltage": {
+        "name": "[%key:component::sensor::entity_component::voltage::name%]"
       },
       "battery_state": {
+        "name": "Battery state",
         "state": {
           "high": "High",
           "medium": "Medium",
@@ -370,7 +713,11 @@
           "poweroff": "Power off"
         }
       },
+      "gas": {
+        "name": "Gas"
+      },
       "lock_alarm": {
+        "name": "Last alert",
         "state": {
           "wrong_finger": "Wrong Finger",
           "wrong_password": "Wrong Passwod",
@@ -389,22 +736,461 @@
         }
       },
       "lock_status": {
+        "name": "Door",
         "state": {
           "open": "[%key:common::state::unlocked%]",
           "closed": "[%key:common::state::locked%]"
         }
       },
       "lock_antilock": {
+        "name": "Double locking status",
         "state": {
           "unlocked": "Unlocked",
           "anti_locked": "Anti locked"
         }
       },
       "lock_insurance": {
+        "name": "Latching status",
         "state": {
           "uninsured_lock": "Uninsured Lock",
           "insured_lock": "Insured Lock"
         }
+      },
+      "lock_last_fingerprint": {
+        "name": "Last ID fingerprint"
+      },
+      "lock_last_password": {
+        "name": "Last ID password"
+      },
+      "lock_last_temporary_password": {
+        "name": "Last ID temporary password"
+      },
+      "lock_last_dynamic_password": {
+        "name": "Last ID dynamic password"
+      },
+      "lock_last_card": {
+        "name": "Last ID card"
+      },
+      "lock_last_identity_card": {
+        "name": "Last ID identity card"
+      },
+      "lock_last_face_recognition": {
+        "name": "Last ID face recognition"
+      },
+      "lock_last_mechanical_key": {
+        "name": "Last ID mechanical key"
+      },
+      "lock_last_iris": {
+        "name": "Last ID iris"
+      },
+      "lock_last_palm_print": {
+        "name": "Last ID palm print"
+      },
+      "lock_last_finger_vein": {
+        "name": "Last ID finger vein"
+      },
+      "lock_last_bluetooth": {
+        "name": "Last ID bluetoot"
+      },
+      "lock_last_remote": {
+        "name": "Last ID remote"
+      },
+      "lock_last_mobile_phone": {
+        "name": "Last ID mobile phone"
+      },
+      "lock_last_voice": {
+        "name": "Last ID voice (remote)"
+      },
+      "lock_last_app": {
+        "name": "Last ID app (remote)"
+      },
+      "lock_last_access_control_system": {
+        "name": "Last ID access control system"
+      },
+      "lock_last_emergency_password": {
+        "name": "Last ID emergency password"
+      },
+      "lock_last_administrator": {
+        "name": "Last ID administrator"
+      },
+      "lock_last_housekeeper": {
+        "name": "Last ID housekeeper"
+      },
+      "formaldehyde": {
+        "name": "[%key:component::tuya::entity::binary_sensor::formaldehyde::name%]"
+      },
+      "luminosity": {
+        "name": "Luminosity"
+      },
+      "smoke_amount": {
+        "name": "Smoke amount"
+      },
+      "current_temperature": {
+        "name": "Current temperature"
+      },
+      "status": {
+        "name": "Status"
+      },
+      "last_amount": {
+        "name": "Last amount"
+      },
+      "remaining_time": {
+        "name": "Remaining time"
+      },
+      "methane": {
+        "name": "[%key:component::tuya::entity::binary_sensor::methane::name%]"
+      },
+      "total_energy": {
+        "name": "Total energy"
+      },
+      "phase_a_current": {
+        "name": "Phase A current"
+      },
+      "phase_a_power": {
+        "name": "Phase A power"
+      },
+      "phase_a_voltage": {
+        "name": "Phase A voltage"
+      },
+      "phase_b_current": {
+        "name": "Phase B current"
+      },
+      "phase_b_power": {
+        "name": "Phase B power"
+      },
+      "phase_b_voltage": {
+        "name": "Phase B voltage"
+      },
+      "phase_c_current": {
+        "name": "Phase C current"
+      },
+      "phase_c_power": {
+        "name": "Phase C power"
+      },
+      "phase_c_voltage": {
+        "name": "Phase C voltage"
+      },
+      "cleaning_area": {
+        "name": "Cleaning area"
+      },
+      "cleaning_time": {
+        "name": "Cleaning time"
+      },
+      "total_cleaning_area": {
+        "name": "Total cleaning area"
+      },
+      "total_cleaning_time": {
+        "name": "Total cleaning time"
+      },
+      "total_cleaning_times": {
+        "name": "Total cleaning times"
+      },
+      "duster_cloth_life": {
+        "name": "Duster cloth lifetime"
+      },
+      "side_brush_life": {
+        "name": "Side brush lifetime"
+      },
+      "filter_life": {
+        "name": "Filter lifetime"
+      },
+      "rolling_brush_life": {
+        "name": "Rolling brush lifetime"
+      },
+      "last_operation_duration": {
+        "name": "Last operation duration"
+      },
+      "water_level": {
+        "name": "Water level"
+      },
+      "total_watering_time": {
+        "name": "Total watering time"
+      },
+      "filter_utilization": {
+        "name": "Filter utilization"
+      },
+      "total_volatile_organic_compound": {
+        "name": "Total volatile organic compound"
+      },
+      "concentration_carbon_dioxide": {
+        "name": "Concentration of carbon dioxide"
+      },
+      "total_operating_time": {
+        "name": "Total operating time"
+      },
+      "total_absorption_particles": {
+        "name": "Total absorption of particles"
+      },
+      "sous_vide_status": {
+        "name": "Status",
+        "state": {
+          "boiling_temp": "Boiling temperature",
+          "cooling": "Cooling",
+          "heating_temp": "Heating temperature",
+          "heating": "Heating",
+          "reserve_1": "Reserve 1",
+          "reserve_2": "Reserve 2",
+          "reserve_3": "Reserve 3",
+          "standby": "[%key:common::state::standby%]",
+          "warm": "Heat preservation"
+        }
+      },
+      "air_quality": {
+        "name": "Air quality",
+        "state": {
+          "great": "Great",
+          "mild": "Mild",
+          "good": "Good",
+          "severe": "Severe"
+        }
+      }
+    },
+    "switch": {
+      "start": {
+        "name": "Start"
+      },
+      "heat_preservation": {
+        "name": "Heat preservation"
+      },
+      "disinfection": {
+        "name": "Disinfection"
+      },
+      "water": {
+        "name": "Water"
+      },
+      "slow_feed": {
+        "name": "Slow feed"
+      },
+      "filter_reset": {
+        "name": "Filter reset"
+      },
+      "water_pump_reset": {
+        "name": "Water pump reset"
+      },
+      "power": {
+        "name": "Power"
+      },
+      "reset_of_water_usage_days": {
+        "name": "Reset of water usage days"
+      },
+      "uv_sterilization": {
+        "name": "UV sterilization"
+      },
+      "plug": {
+        "name": "Plug"
+      },
+      "child_lock": {
+        "name": "Child lock"
+      },
+      "switch": {
+        "name": "Switch"
+      },
+      "socket": {
+        "name": "Socket"
+      },
+      "radio": {
+        "name": "Radio"
+      },
+      "alarm_1": {
+        "name": "Alarm 1"
+      },
+      "alarm_2": {
+        "name": "Alarm 2"
+      },
+      "alarm_3": {
+        "name": "Alarm 3"
+      },
+      "alarm_4": {
+        "name": "Alarm 4"
+      },
+      "sleep_aid": {
+        "name": "Sleep aid"
+      },
+      "switch_1": {
+        "name": "Switch 1"
+      },
+      "switch_2": {
+        "name": "Switch 2"
+      },
+      "switch_3": {
+        "name": "Switch 3"
+      },
+      "switch_4": {
+        "name": "Switch 4"
+      },
+      "switch_5": {
+        "name": "Switch 5"
+      },
+      "switch_6": {
+        "name": "Switch 6"
+      },
+      "switch_7": {
+        "name": "Switch 7"
+      },
+      "switch_8": {
+        "name": "Switch 8"
+      },
+      "usb_1": {
+        "name": "USB 1"
+      },
+      "usb_2": {
+        "name": "USB 2"
+      },
+      "usb_3": {
+        "name": "USB 3"
+      },
+      "usb_4": {
+        "name": "USB 4"
+      },
+      "usb_5": {
+        "name": "USB 5"
+      },
+      "usb_6": {
+        "name": "USB 6"
+      },
+      "socket_1": {
+        "name": "Socket 1"
+      },
+      "socket_2": {
+        "name": "Socket 2"
+      },
+      "socket_3": {
+        "name": "Socket 3"
+      },
+      "socket_4": {
+        "name": "Socket 4"
+      },
+      "socket_5": {
+        "name": "Socket 5"
+      },
+      "socket_6": {
+        "name": "Socket 6"
+      },
+      "ionizer": {
+        "name": "Ionizer"
+      },
+      "filter_cartridge_reset": {
+        "name": "Filter cartridge reset"
+      },
+      "humidification": {
+        "name": "Humidification"
+      },
+      "do_not_disturb": {
+        "name": "Do not disturb"
+      },
+      "mute_voice": {
+        "name": "Mute voice"
+      },
+      "mute": {
+        "name": "Mute"
+      },
+      "battery_lock": {
+        "name": "Battery lock"
+      },
+      "cry_detection": {
+        "name": "Cry detection"
+      },
+      "sound_detection": {
+        "name": "Sound detection"
+      },
+      "video_recording": {
+        "name": "Video recording"
+      },
+      "motion_recording": {
+        "name": "Motion recording"
+      },
+      "privacy_mode": {
+        "name": "Privacy mode"
+      },
+      "flip": {
+        "name": "Flip"
+      },
+      "time_watermark": {
+        "name": "Time watermark"
+      },
+      "wide_dynamic_range": {
+        "name": "Wide dynamic range"
+      },
+      "motion_tracking": {
+        "name": "Motion tracking"
+      },
+      "motion_alarm": {
+        "name": "Motion alarm"
+      },
+      "energy_saving": {
+        "name": "Energy saving"
+      },
+      "open_window_detection": {
+        "name": "Open window detection"
+      },
+      "spray": {
+        "name": "Spray"
+      },
+      "voice": {
+        "name": "Voice"
+      },
+      "anion": {
+        "name": "Anion"
+      },
+      "oxygen_bar": {
+        "name": "Oxygen bar"
+      },
+      "natural_wind": {
+        "name": "Natural wind"
+      },
+      "sound": {
+        "name": "Sound"
+      },
+      "reverse": {
+        "name": "Reverse"
+      },
+      "sleep": {
+        "name": "Sleep"
+      },
+      "sterilization": {
+        "name": "Sterilization"
+      },
+      "lock_auto": {
+        "name": "Auto-lock"
+      },
+      "lock_arming": {
+        "name": "Arming"
+      },
+      "lock_hibernation": {
+        "name": "Hibernation"
+      },
+      "lock_verification_free": {
+        "name": "Verification-free"
+      },
+      "lock_double_locking_limit": {
+        "name": "Double locking limit"
+      },
+      "disconnection_alert": {
+        "name": "Disconnection alert"
+      },
+      "lock_function": {
+        "name": "Lock function"
+      },
+      "lock_mandatory_double": {
+        "name": "Mandatory double locking"
+      },
+      "lock_phone_call": {
+        "name": "Phone call"
+      },
+      "lock_normally_open": {
+        "name": "Normally open"
+      },
+      "lock_special_control": {
+        "name": "Special control"
+      },
+      "lock_wakeup": {
+        "name": "Wake-up status"
+      },
+      "lock_password_free_feedback": {
+        "name": "Password-free unlocking feedback"
+      },
+      "lock_unlock_secret_key": {
+        "name": "Unlock with special secret key"
       }
     }
   }

--- a/custom_components/tuya/switch.py
+++ b/custom_components/tuya/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.switch import (
     SwitchDeviceClass,
@@ -29,12 +29,12 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "bh": (
         SwitchEntityDescription(
             key=DPCode.START,
-            name="Start",
+            translation_key="start",
             icon="mdi:kettle-steam",
         ),
         SwitchEntityDescription(
             key=DPCode.WARM,
-            name="Heat preservation",
+            translation_key="heat_preservation",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -43,12 +43,12 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "cn": (
         SwitchEntityDescription(
             key=DPCode.DISINFECTION,
-            name="Disinfection",
+            translation_key="disinfection",
             icon="mdi:bacteria",
         ),
         SwitchEntityDescription(
             key=DPCode.WATER,
-            name="Water",
+            translation_key="water",
             icon="mdi:water",
         ),
     ),
@@ -57,7 +57,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "cwwsq": (
         SwitchEntityDescription(
             key=DPCode.SLOW_FEED,
-            name="Slow feed",
+            translation_key="slow_feed",
             icon="mdi:speedometer-slow",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -67,29 +67,29 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "cwysj": (
         SwitchEntityDescription(
             key=DPCode.FILTER_RESET,
-            name="Filter reset",
+            translation_key="filter_reset",
             icon="mdi:filter",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.PUMP_RESET,
-            name="Water pump reset",
+            translation_key="water_pump_reset",
             icon="mdi:pump",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Power",
+            translation_key="power",
         ),
         SwitchEntityDescription(
             key=DPCode.WATER_RESET,
-            name="Reset of water usage days",
+            translation_key="reset_of_water_usage_days",
             icon="mdi:water-sync",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.UV,
-            name="UV sterilization",
+            translation_key="uv_sterilization",
             icon="mdi:lightbulb",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -102,20 +102,20 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
         # switch to control the plug.
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Plug",
+            translation_key="plug",
         ),
     ),
-    # Cirquit Breaker
+    # Circuit Breaker
     "dlq": (
         SwitchEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Switch",
+            translation_key="switch",
         ),
     ),
     # Wake Up Light II
@@ -123,36 +123,36 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "hxd": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Radio",
+            translation_key="radio",
             icon="mdi:radio",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_2,
-            name="Alarm 1",
+            translation_key="alarm_1",
             icon="mdi:alarm",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_3,
-            name="Alarm 2",
+            translation_key="alarm_2",
             icon="mdi:alarm",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_4,
-            name="Alarm 3",
+            translation_key="alarm_3",
             icon="mdi:alarm",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_5,
-            name="Alarm 4",
+            translation_key="alarm_4",
             icon="mdi:alarm",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_6,
-            name="Sleep aid",
+            translation_key="sleep_aid",
             icon="mdi:power-sleep",
         ),
     ),
@@ -162,12 +162,12 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "wkcz": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Switch 1",
+            translation_key="switch_1",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_2,
-            name="Switch 2",
+            translation_key="switch_2",
             device_class=SwitchDeviceClass.OUTLET,
         ),
     ),
@@ -176,77 +176,77 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "kg": (
         SwitchEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Switch 1",
+            translation_key="switch_1",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_2,
-            name="Switch 2",
+            translation_key="switch_2",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_3,
-            name="Switch 3",
+            translation_key="switch_3",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_4,
-            name="Switch 4",
+            translation_key="switch_4",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_5,
-            name="Switch 5",
+            translation_key="switch_5",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_6,
-            name="Switch 6",
+            translation_key="switch_6",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_7,
-            name="Switch 7",
+            translation_key="switch_7",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_8,
-            name="Switch 8",
+            translation_key="switch_8",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB1,
-            name="USB 1",
+            translation_key="usb_1",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB2,
-            name="USB 2",
+            translation_key="usb_2",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB3,
-            name="USB 3",
+            translation_key="usb_3",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB4,
-            name="USB 4",
+            translation_key="usb_4",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB5,
-            name="USB 5",
+            translation_key="usb_5",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB6,
-            name="USB 6",
+            translation_key="usb_6",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Switch",
+            translation_key="switch",
             device_class=SwitchDeviceClass.OUTLET,
         ),
     ),
@@ -255,35 +255,35 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "kj": (
         SwitchEntityDescription(
             key=DPCode.ANION,
-            name="Ionizer",
+            translation_key="ionizer",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.FILTER_RESET,
-            name="Filter cartridge reset",
+            translation_key="filter_cartridge_reset",
             icon="mdi:filter",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Power",
+            translation_key="power",
         ),
         SwitchEntityDescription(
             key=DPCode.WET,
-            name="Humidification",
+            translation_key="humidification",
             icon="mdi:water-percent",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.UV,
-            name="UV sterilization",
+            translation_key="uv_sterilization",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -293,13 +293,13 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "kt": (
         SwitchEntityDescription(
             key=DPCode.ANION,
-            name="Ionizer",
+            translation_key="ionizer",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -309,100 +309,100 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "ms": (
         SwitchEntityDescription(
             key=DPCode.AUTOMATIC_LOCK,
-            name="Auto-lock",
             icon="mdi:lock-clock",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_auto",
         ),
         SwitchEntityDescription(
             key=DPCode.ARMING_SWITCH,
-            name="Arming",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_arming",
         ),
         SwitchEntityDescription(
             key=DPCode.DO_NOT_DISTURB,
-            name="Do not disturb",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="do_not_disturb",
         ),
         SwitchEntityDescription(
             key=DPCode.DORMANT_SWITCH,
-            name="Hibernation",
             icon="mdi:sleep",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_hibernation",
         ),
         SwitchEntityDescription(
             key=DPCode.FREE_VERIFY,
-            name="Verification-free",
             icon="mdi:shield-lock-open-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_verification_free",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_ANTILOCK_LIMIT,
-            name="Double locking limit",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_double_locking_limit",
         ),
         SwitchEntityDescription(
             key=DPCode.ALARM_SWITCH,
-            name="Disconnection alert",
             icon="mdi:close-network-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="disconnection_alert",
         ),
         SwitchEntityDescription(
             key=DPCode.LOCK_FUNCTION_SWITCH,
-            name="Lock function",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_function",
         ),
         SwitchEntityDescription(
             key=DPCode.ENFORCE_LOCK_UP,
-            name="Mandatory double locking",
             icon="mdi:lock-check",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_mandatory_double",
         ),
         SwitchEntityDescription(
             key=DPCode.CALLPHONE,
-            name="Phone call",
             icon="mdi:phone-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_phone_call",
         ),
         SwitchEntityDescription(
             key=DPCode.NORMAL_OPEN_SWITCH,
-            name="Normally open",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_normally_open",
         ),
         SwitchEntityDescription(
             key=DPCode.SPECIAL_CONTROL,
-            name="Special control",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_special_control",
         ),
         SwitchEntityDescription(
             key=DPCode.BASIC_OSD,
-            name="Camera time watermark",
             icon="mdi:watermark",
             entity_category=EntityCategory.CONFIG,
+            translation_key="time_watermark",
         ),
         SwitchEntityDescription(
             key=DPCode.BASIC_PRIVATE,
-            name="Camera privacy mode",
             icon="mdi:camera-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="privacy_mode",
         ),
         SwitchEntityDescription(
             key=DPCode.WIRELESS_AWAKE,
-            name="Wake-up status",
             icon="mdi:list-status",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_wakeup",
         ),
         SwitchEntityDescription(
             key=DPCode.REMOTE_RESULT,
-            name="Password-free unlocking feedback",
             icon="mdi:lock-alert-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_password_free_feedback",
         ),
         SwitchEntityDescription(
             key=DPCode.UNLOCK_SPECIAL,
-            name="Unlock with special secret key",
             icon="mdi:account-key-outline",
             entity_category=EntityCategory.CONFIG,
+            translation_key="lock_unlock_secret_key",
         ),
     ),
     # Sous Vide Cooker
@@ -410,13 +410,13 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "mzj": (
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Switch",
+            translation_key="switch",
             icon="mdi:power",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.START,
-            name="Start",
+            translation_key="start",
             icon="mdi:pot-steam",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -426,67 +426,67 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "pc": (
         SwitchEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Socket 1",
+            translation_key="socket_1",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_2,
-            name="Socket 2",
+            translation_key="socket_2",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_3,
-            name="Socket 3",
+            translation_key="socket_3",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_4,
-            name="Socket 4",
+            translation_key="socket_4",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_5,
-            name="Socket 5",
+            translation_key="socket_5",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_6,
-            name="Socket 6",
+            translation_key="socket_6",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB1,
-            name="USB 1",
+            translation_key="usb_1",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB2,
-            name="USB 2",
+            translation_key="usb_2",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB3,
-            name="USB 3",
+            translation_key="usb_3",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB4,
-            name="USB 4",
+            translation_key="usb_4",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB5,
-            name="USB 5",
+            translation_key="usb_5",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_USB6,
-            name="USB 6",
+            translation_key="usb_6",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Socket",
+            translation_key="socket",
             device_class=SwitchDeviceClass.OUTLET,
         ),
     ),
@@ -496,7 +496,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "qjdcz": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Switch",
+            translation_key="switch",
         ),
     ),
     # Heater
@@ -504,13 +504,13 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "qn": (
         SwitchEntityDescription(
             key=DPCode.ANION,
-            name="Ionizer",
+            translation_key="ionizer",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -520,15 +520,23 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "sd": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_DISTURB,
-            name="Do not disturb",
+            translation_key="do_not_disturb",
             icon="mdi:minus-circle",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.VOICE_SWITCH,
-            name="Mute voice",
+            translation_key="mute_voice",
             icon="mdi:account-voice",
             entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+    # Smart Water Timer
+    "sfkzq": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            translation_key="switch",
+            icon="mdi:sprinkler-variant",
         ),
     ),
     # Siren Alarm
@@ -536,7 +544,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "sgbj": (
         SwitchEntityDescription(
             key=DPCode.MUFFLING,
-            name="Mute",
+            translation_key="mute",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -545,68 +553,68 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "sp": (
         SwitchEntityDescription(
             key=DPCode.WIRELESS_BATTERYLOCK,
-            name="Battery lock",
+            translation_key="battery_lock",
             icon="mdi:battery-lock",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.CRY_DETECTION_SWITCH,
+            translation_key="cry_detection",
             icon="mdi:emoticon-cry",
-            name="Cry detection",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.DECIBEL_SWITCH,
+            translation_key="sound_detection",
             icon="mdi:microphone-outline",
-            name="Sound detection",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.RECORD_SWITCH,
+            translation_key="video_recording",
             icon="mdi:record-rec",
-            name="Video recording",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.MOTION_RECORD,
+            translation_key="motion_recording",
             icon="mdi:record-rec",
-            name="Motion recording",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.BASIC_PRIVATE,
+            translation_key="privacy_mode",
             icon="mdi:eye-off",
-            name="Privacy mode",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.BASIC_FLIP,
+            translation_key="flip",
             icon="mdi:flip-horizontal",
-            name="Flip",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.BASIC_OSD,
+            translation_key="time_watermark",
             icon="mdi:watermark",
-            name="Time watermark",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.BASIC_WDR,
+            translation_key="wide_dynamic_range",
             icon="mdi:watermark",
-            name="Wide dynamic range",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.MOTION_TRACKING,
+            translation_key="motion_tracking",
             icon="mdi:motion-sensor",
-            name="Motion tracking",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.MOTION_SWITCH,
+            translation_key="motion_alarm",
             icon="mdi:motion-sensor",
-            name="Motion alarm",
             entity_category=EntityCategory.CONFIG,
         ),
     ),
@@ -614,7 +622,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "szjqr": (
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Switch",
+            translation_key="switch",
             icon="mdi:cursor-pointer",
         ),
     ),
@@ -623,27 +631,27 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "tdq": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_1,
-            name="Switch 1",
+            translation_key="switch_1",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_2,
-            name="Switch 2",
+            translation_key="switch_2",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_3,
-            name="Switch 3",
+            translation_key="switch_3",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_4,
-            name="Switch 4",
+            translation_key="switch_4",
             device_class=SwitchDeviceClass.OUTLET,
         ),
         SwitchEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -653,7 +661,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "tyndj": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_SAVE_ENERGY,
-            name="Energy saving",
+            translation_key="energy_saving",
             icon="mdi:leaf",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -663,15 +671,22 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "wkf": (
         SwitchEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.WINDOW_CHECK,
-            name="Open window detection",
+            translation_key="open_window_detection",
             icon="mdi:window-open",
             entity_category=EntityCategory.CONFIG,
+        ),
+    ),
+    # Air Conditioner Mate (Smart IR Socket)
+    "wnykq": (
+        SwitchEntityDescription(
+            key=DPCode.SWITCH,
+            name=None,
         ),
     ),
     # SIREN: Siren (switch) with Temperature and humidity sensor
@@ -679,7 +694,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "wsdcg": (
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Switch",
+            translation_key="switch",
             device_class=SwitchDeviceClass.OUTLET,
         ),
     ),
@@ -688,7 +703,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "xdd": (
         SwitchEntityDescription(
             key=DPCode.DO_NOT_DISTURB,
-            name="Do not disturb",
+            translation_key="do_not_disturb",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -698,16 +713,16 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "xxj": (
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Power",
+            translation_key="power",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_SPRAY,
-            name="Spray",
+            translation_key="spray",
             icon="mdi:spray",
         ),
         SwitchEntityDescription(
             key=DPCode.SWITCH_VOICE,
-            name="Voice",
+            translation_key="voice",
             icon="mdi:account-voice",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -717,7 +732,7 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "zndb": (
         SwitchEntityDescription(
             key=DPCode.SWITCH,
-            name="Switch",
+            translation_key="switch",
         ),
     ),
     # Fan
@@ -725,37 +740,37 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "fs": (
         SwitchEntityDescription(
             key=DPCode.ANION,
-            name="Anion",
+            translation_key="anion",
             icon="mdi:atom",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.HUMIDIFIER,
-            name="Humidification",
+            translation_key="humidification",
             icon="mdi:air-humidifier",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.OXYGEN,
-            name="Oxygen bar",
+            translation_key="oxygen_bar",
             icon="mdi:molecule",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.FAN_COOL,
-            name="Natural wind",
+            translation_key="natural_wind",
             icon="mdi:weather-windy",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.FAN_BEEP,
-            name="Sound",
+            translation_key="sound",
             icon="mdi:minus-circle",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.CHILD_LOCK,
-            name="Child lock",
+            translation_key="child_lock",
             icon="mdi:account-lock",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -765,13 +780,13 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "cl": (
         SwitchEntityDescription(
             key=DPCode.CONTROL_BACK,
-            name="Reverse",
+            translation_key="reverse",
             icon="mdi:swap-horizontal",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.OPPOSITE,
-            name="Reverse",
+            translation_key="reverse",
             icon="mdi:swap-horizontal",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -781,19 +796,19 @@ SWITCHES: dict[str, tuple[SwitchEntityDescription, ...]] = {
     "jsq": (
         SwitchEntityDescription(
             key=DPCode.SWITCH_SOUND,
-            name="Voice",
+            translation_key="voice",
             icon="mdi:account-voice",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.SLEEP,
-            name="Sleep",
+            translation_key="sleep",
             icon="mdi:power-sleep",
             entity_category=EntityCategory.CONFIG,
         ),
         SwitchEntityDescription(
             key=DPCode.STERILIZATION,
-            name="Sterilization",
+            translation_key="sterilization",
             icon="mdi:minus-circle-outline",
             entity_category=EntityCategory.CONFIG,
         ),
@@ -828,19 +843,17 @@ async def async_setup_entry(
         """Discover and add a discovered tuya sensor."""
         entities: list[TuyaSwitchEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if descriptions := SWITCHES.get(device.category):
                 for description in descriptions:
                     if description.key in device.status:
                         entities.append(
-                            TuyaSwitchEntity(
-                                device, hass_data.device_manager, description
-                            )
+                            TuyaSwitchEntity(device, hass_data.manager, description)
                         )
 
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -852,8 +865,8 @@ class TuyaSwitchEntity(TuyaEntity, SwitchEntity):
 
     def __init__(
         self,
-        device: TuyaDevice,
-        device_manager: TuyaDeviceManager,
+        device: CustomerDevice,
+        device_manager: Manager,
         description: SwitchEntityDescription,
     ) -> None:
         """Init TuyaHaSwitch."""

--- a/custom_components/tuya/vacuum.py
+++ b/custom_components/tuya/vacuum.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from tuya_iot import TuyaDevice, TuyaDeviceManager
+from tuya_sharing import CustomerDevice, Manager
 
 from homeassistant.components.vacuum import (
     STATE_CLEANING,
@@ -61,12 +61,12 @@ async def async_setup_entry(
         """Discover and add a discovered Tuya vacuum."""
         entities: list[TuyaVacuumEntity] = []
         for device_id in device_ids:
-            device = hass_data.device_manager.device_map[device_id]
+            device = hass_data.manager.device_map[device_id]
             if device.category == "sd":
-                entities.append(TuyaVacuumEntity(device, hass_data.device_manager))
+                entities.append(TuyaVacuumEntity(device, hass_data.manager))
         async_add_entities(entities)
 
-    async_discover_device([*hass_data.device_manager.device_map])
+    async_discover_device([*hass_data.manager.device_map])
 
     entry.async_on_unload(
         async_dispatcher_connect(hass, TUYA_DISCOVERY_NEW, async_discover_device)
@@ -78,14 +78,17 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
     _fan_speed: EnumTypeData | None = None
     _battery_level: IntegerTypeData | None = None
+    _attr_name = None
 
-    def __init__(self, device: TuyaDevice, device_manager: TuyaDeviceManager) -> None:
+    def __init__(self, device: CustomerDevice, device_manager: Manager) -> None:
         """Init Tuya vacuum."""
         super().__init__(device, device_manager)
 
         self._attr_fan_speed_list = []
 
-        self._attr_supported_features |= VacuumEntityFeature.SEND_COMMAND
+        self._attr_supported_features = (
+            VacuumEntityFeature.SEND_COMMAND | VacuumEntityFeature.STATE
+        )
         if self.find_dpcode(DPCode.PAUSE, prefer_function=True):
             self._attr_supported_features |= VacuumEntityFeature.PAUSE
 
@@ -100,16 +103,6 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
 
         if self.find_dpcode(DPCode.SEEK, prefer_function=True):
             self._attr_supported_features |= VacuumEntityFeature.LOCATE
-
-        if self.find_dpcode(DPCode.STATUS, prefer_function=True):
-            self._attr_supported_features |= (
-                VacuumEntityFeature.STATE | VacuumEntityFeature.STATUS
-            )
-
-        if self.find_dpcode(DPCode.POWER, prefer_function=True):
-            self._attr_supported_features |= (
-                VacuumEntityFeature.TURN_ON | VacuumEntityFeature.TURN_OFF
-            )
 
         if self.find_dpcode(DPCode.POWER_GO, prefer_function=True):
             self._attr_supported_features |= (
@@ -151,14 +144,6 @@ class TuyaVacuumEntity(TuyaEntity, StateVacuumEntity):
         if not (status := self.device.status.get(DPCode.STATUS)):
             return None
         return TUYA_STATUS_TO_HA.get(status)
-
-    def turn_on(self, **kwargs: Any) -> None:
-        """Turn the device on."""
-        self._send_command([{"code": DPCode.POWER, "value": True}])
-
-    def turn_off(self, **kwargs: Any) -> None:
-        """Turn the device off."""
-        self._send_command([{"code": DPCode.POWER, "value": False}])
 
     def start(self, **kwargs: Any) -> None:
         """Start the device."""


### PR DESCRIPTION
# Breaking change
Migrate Tuya integration to new sharing SDK
Tuya has provided an easier and improved login method for Home Assistant users. Having a developer account with Tuya is no longer required; instead, you can scan a QR code with your Tuya Smart of Smart Life app to authenticate it with Home Assistant.

After the upgrade, Home Assistant will ask you to re-authenticate your Tuya Smart or Smart Life account using this new method.

# Proposed change
This PR moves the Tuya integration onto the new sharing SDK, which removes the need for a developer account and can directly log users in by scanning a QR code using the Smart Life or the Tuya app.

This is powered by their new package: https://github.com/tuya/tuya-device-sharing-sdk/

This PR offers a migration path. On upgrade, a re-auth will be triggered that will request the user to log in using their Smart Life / Tuya Smart app. After re-auth, everything will continue to work as usual.

This PR is a combination of the work done in core#103007 and core#104767, updated to handle our latest features/standards.

Tested against both Tuya Smart and Smart Life accounts, with new integration setups and migrating ones, with a variety of devices (heater, AC, a bunch of bulbs, Christmas lights, doorbell camera, and siren).